### PR TITLE
initial ieee802.15.4 API

### DIFF
--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -260,7 +260,7 @@ impl<'c> Radio<'c> {
     }
 
     /// Sample the received signal power (i.e. the presence of possibly interfering signals)
-    /// within the bandwidth of the currently used channel for sample_cycles iterations.
+    /// within the bandwidth of the currently used channel for `sample_cycles` iterations.
     /// Note that one iteration has a sample time of 128μs, and that each iteration produces the
     /// average RSSI value measured during this sample time.
     ///
@@ -294,14 +294,14 @@ impl<'c> Radio<'c> {
                 self.radio.events_edend.reset();
 
                 // note that since we have increased EDCNT, the EDSAMPLE register contains the
-                // maximumrecorded value, not the average
+                // maximum recorded value, not the average
                 let read_lvl = self.radio.edsample.read().edlvl().bits();
                 return read_lvl;
             }
         }
     }
 
-    /// Recevies one radio packet and copies its contents into the given `packet` buffer
+    /// Receives one radio packet and copies its contents into the given `packet` buffer
     ///
     /// This methods returns the `Ok` variant if the CRC included the packet was successfully
     /// validated by the hardware; otherwise it returns the `Err` variant. In either case, `packet`
@@ -645,9 +645,7 @@ impl<'c> Radio<'c> {
     fn wait_for_event(&self, event: Event) {
         match event {
             Event::End => {
-                while self.radio.events_end.read().events_end().bit_is_clear() {
-                    continue;
-                }
+                while self.radio.events_end.read().events_end().bit_is_clear() {}
                 self.radio.events_end.reset();
             }
             Event::PhyEnd => {
@@ -657,9 +655,7 @@ impl<'c> Radio<'c> {
                     .read()
                     .events_phyend()
                     .bit_is_clear()
-                {
-                    continue;
-                }
+                {}
                 self.radio.events_phyend.reset();
             }
         }
@@ -667,9 +663,7 @@ impl<'c> Radio<'c> {
 
     /// Waits until the radio state matches the given `state`
     fn wait_for_state_a(&self, state: STATE_A) {
-        while self.radio.state.read().state() != state {
-            continue;
-        }
+        while self.radio.state.read().state() != state {}
     }
 }
 

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -583,7 +583,7 @@ impl Packet {
     /// NOTE `src` data will be truncated to `MAX_PACKET_SIZE` bytes
     pub fn copy_from_slice(&mut self, src: &[u8]) {
         let len = cmp::min(src.len(), Self::MAX_LEN as usize) as u8;
-        self.buffer[Self::DATA][..len as usize].copy_from_slice(src);
+        self.buffer[Self::DATA][..len as usize].copy_from_slice(&src[..len.into()]);
         self.set_len(len);
     }
 

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -3,6 +3,7 @@
 use core::{
     ops::{self, RangeFrom},
     sync::atomic::{self, Ordering},
+    marker::PhantomData,
 };
 
 use embedded_hal::timer::CountDown as _;
@@ -23,7 +24,7 @@ pub struct Radio<'c> {
     // RADIO needs to be (re-)enabled to pick up new settings
     needs_enable: bool,
     // used to freeze `Clocks`
-    _clocks: &'c (),
+    _clocks: PhantomData<&'c ()>,
 }
 
 /// Default Clear Channel Assessment method = Carrier sense
@@ -153,7 +154,7 @@ impl<'c> Radio<'c> {
         let mut radio = Self {
             needs_enable: false,
             radio,
-            _clocks: &(),
+            _clocks: PhantomData,
         };
 
         // shortcuts will be kept off by default and only be temporarily enabled within blocking

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -590,7 +590,7 @@ impl Packet {
     /// Maximum amount of usable payload (CRC excluded) a single packet can contain, in bytes
     pub const CAPACITY: u8 = 125;
     const CRC: u8 = 2; // size of the CRC, which is *never* copied to / from RAM
-    const MAX_PSDU_LEN: u8 = Self::CAPACITY + 2 /* Self::CRC */;
+    const MAX_PSDU_LEN: u8 = Self::CAPACITY + Self::CRC;
     const SIZE: usize = 1 /* PHR */ + Self::MAX_PSDU_LEN as usize;
 
     /// Returns an empty packet (length = 0)

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -312,7 +312,7 @@ impl<'c> Radio<'c> {
                 .bit_is_set()
             {
                 // channel is busy
-                self.radio.events_ccaidle.reset();
+                self.radio.events_ccabusy.reset();
                 return Err(());
             }
         }
@@ -388,7 +388,7 @@ impl<'c> Radio<'c> {
                     .bit_is_set()
                 {
                     // channel is busy
-                    self.radio.events_ccaidle.reset();
+                    self.radio.events_ccabusy.reset();
                     continue 'cca;
                 }
             }

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -278,7 +278,7 @@ impl<'c> Radio<'c> {
 
         // due to a shortcut the transmission will start automatically so we just have to wait
         // until the END event
-        self.wait_for_event(Event::End);
+        self.wait_for_event(Event::PhyEnd);
         dma_end_fence();
     }
 
@@ -381,6 +381,12 @@ impl<'c> Radio<'c> {
                 }
                 self.radio.events_end.reset();
             }
+            Event::PhyEnd => {
+                while self.radio.events_phyend.read().events_phyend().bit_is_clear() {
+                    continue;
+                }
+                self.radio.events_phyend.reset();
+            }
         }
     }
 
@@ -404,6 +410,7 @@ fn dma_end_fence() {
 
 enum Event {
     End,
+    PhyEnd,
 }
 
 /// An IEEE 802.15.4 packet

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -25,6 +25,9 @@ pub const DEFAULT_CHANNEL: Channel = Channel::_20;
 /// Default TX power = 0 dBm
 pub const DEFAULT_TXPOWER: i8 = 0;
 
+/// Default Start of Frame Delimiter = `0xA7` (IEEE compliant)
+pub const DEFAULT_SFD: u8 = 0xA7;
+
 // TODO expose the other variants in `pac::CCAMODE_A`
 /// Clear Channel Assessment method
 pub enum Cca {
@@ -136,8 +139,9 @@ impl<'c> Radio<'c> {
         }
 
         // set default settings
-        radio.set_channel(DEFAULT_CHANNEL);
         radio.set_cca(DEFAULT_CCA);
+        radio.set_channel(DEFAULT_CHANNEL);
+        radio.set_sfd(DEFAULT_SFD);
         radio.set_txpower(DEFAULT_TXPOWER);
 
         radio
@@ -162,6 +166,14 @@ impl<'c> Radio<'c> {
         match cca {
             Cca::CarrierSense => self.radio.ccactrl.write(|w| w.ccamode().carrier_mode()),
         }
+    }
+
+    /// Changes the Start of Frame Delimiter
+    pub fn set_sfd(&mut self, sfd: u8) {
+        // FIXME don't completely turn off the radio; RXIDLE or TXIDLE are probably OK
+        self.disable();
+
+        self.radio.sfd.write(|w| unsafe { w.sfd().bits(sfd) });
     }
 
     /// Changes the TX power

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -264,7 +264,7 @@ impl<'c> Radio<'c> {
         }
     }
 
-    /// Listens for a packet for no longer than the specified amount of milliseconds
+    /// Listens for a packet for no longer than the specified amount of microseconds
     ///
     /// If no packet is received within the specified time then the `Timeout` error is returned
     ///
@@ -272,19 +272,19 @@ impl<'c> Radio<'c> {
     /// incorrect then the `Crc` error is returned; otherwise the `Ok` variant is returned.
     ///
     /// Note that the time it takes to switch the radio to RX mode is included in the timeout count.
-    /// This transition may take up to a hundred of milliseconds; see the section 6.20.15.8 in the
+    /// This transition may take up to a hundred of microseconds; see the section 6.20.15.8 in the
     /// Product Specification for more details about timing
     pub fn recv_timeout<I>(
         &mut self,
         packet: &mut Packet,
         timer: &mut Timer<I>,
-        millis: u32,
+        microseconds: u32,
     ) -> Result<u16, Error>
     where
         I: timer::Instance,
     {
         // Start the timeout timer
-        timer.start(millis);
+        timer.start(microseconds);
 
         // Start the read
         self.start_recv(packet);

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -30,8 +30,8 @@ pub struct Radio<'c> {
 /// Default Clear Channel Assessment method = Carrier sense
 pub const DEFAULT_CCA: Cca = Cca::CarrierSense;
 
-/// Default radio channel = Channel 20 (`2_450` MHz)
-pub const DEFAULT_CHANNEL: Channel = Channel::_18; // _17 todo undo; set this to interfere with my wifi
+/// Default radio channel = Channel 11 (`2_405` MHz)
+pub const DEFAULT_CHANNEL: Channel = Channel::_11;
 
 /// Default TX power = 0 dBm
 pub const DEFAULT_TXPOWER: TxPower = TxPower::_0dBm;

--- a/nrf52840-hal/src/ieee802154.rs
+++ b/nrf52840-hal/src/ieee802154.rs
@@ -1,0 +1,421 @@
+//! IEEE 802.15.4 radio
+
+use core::{
+    cmp,
+    ops::{self, RangeFrom},
+    sync::atomic::{self, Ordering},
+};
+
+use crate::clocks::{Clocks, ExternalOscillator};
+use crate::pac::{generic::Variant, radio::state::STATE_A, RADIO};
+
+pub struct Radio<'c> {
+    radio: RADIO,
+    // used to freeze `Clocks`
+    _clocks: &'c (),
+}
+
+/// Default Clear Channel Assessment method = Carrier sense
+pub const DEFAULT_CCA: Cca = Cca::CarrierSense;
+
+/// Default radio channel = Channel 20 (2_450 MHz)
+pub const DEFAULT_CHANNEL: Channel = Channel::_20;
+
+// TODO expose the other variants in `pac::CCAMODE_A`
+/// Clear Channel Assessment method
+pub enum Cca {
+    /// Carrier sense
+    CarrierSense,
+}
+
+/// IEEE 802.15.4 channels
+///
+/// NOTE these are NOT the same as WiFi 2.4 GHz channels
+pub enum Channel {
+    /// 2_405 MHz
+    _11 = 5,
+    /// 2_410 MHz
+    _12 = 10,
+    /// 2_415 MHz
+    _13 = 15,
+    /// 2_420 MHz
+    _14 = 20,
+    /// 2_425 MHz
+    _15 = 25,
+    /// 2_430 MHz
+    _16 = 30,
+    /// 2_435 MHz
+    _17 = 35,
+    /// 2_440 MHz
+    _18 = 40,
+    /// 2_445 MHz
+    _19 = 45,
+    /// 2_450 MHz
+    _20 = 50,
+    /// 2_455 MHz
+    _21 = 55,
+    /// 2_460 MHz
+    _22 = 60,
+    /// 2_465 MHz
+    _23 = 65,
+    /// 2_470 MHz
+    _24 = 70,
+    /// 2_475 MHz
+    _25 = 75,
+    /// 2_480 MHz
+    _26 = 80,
+}
+
+// TODO add API to change TXPOWER
+impl<'c> Radio<'c> {
+    /// Initializes the radio for IEEE 802.15.4 operation
+    pub fn init<L, LSTAT>(radio: RADIO, _clocks: &'c Clocks<ExternalOscillator, L, LSTAT>) -> Self {
+        let mut radio = Self { radio, _clocks: &() };
+
+        // go to a known state
+        radio.disable();
+
+        // clear any event interesting to us
+        radio.radio.events_disabled.reset();
+        radio.radio.events_end.reset();
+
+        radio.radio.mode.write(|w| w.mode().ieee802154_250kbit());
+
+        // NOTE(unsafe) radio is currently disabled
+        unsafe {
+            radio.radio.pcnf0.write(|w| {
+                w.s1incl()
+                    .clear_bit() // S1 not included in RAM
+                    .plen()
+                    ._32bit_zero() // 32-bit zero preamble
+                    .crcinc()
+                    .exclude() // no CRC
+                    .cilen()
+                    .bits(0) // no code indicator
+                    .lflen()
+                    .bits(8) // length = 8 bits
+                    .s0len()
+                    .clear_bit() // no S0
+                    .s1len()
+                    .bits(0) // no S1
+            });
+
+            radio.radio.pcnf1.write(|w| {
+                w.maxlen()
+                    .bits(1 /* PHY_HDR */ + Packet::MAX_LEN) // LQI is not transmitted
+                    .statlen()
+                    .bits(0) // no static length
+                    .balen()
+                    .bits(0) // no base address
+                    .endian()
+                    .clear_bit() // little endian
+                    .whiteen()
+                    .clear_bit() // no data whitenining
+            });
+
+            // CRC configuration required by the IEEE spec: x**16 + x**12 + x**5 + 1
+            radio
+                .radio
+                .crccnf
+                .write(|w| w.len().two().skipaddr().ieee802154());
+            radio.radio.crcpoly.write(|w| w.crcpoly().bits(0x11021));
+            radio.radio.crcinit.write(|w| w.crcinit().bits(0));
+
+            // permanent shortcuts
+            radio
+                .radio
+                .shorts
+                .write(|w| w.ccaidle_txen().set_bit().txready_start().set_bit());
+        }
+
+        // set default settings
+        radio.set_channel(DEFAULT_CHANNEL);
+        radio.set_cca(DEFAULT_CCA);
+
+        radio
+    }
+
+    /// Changes the radio channel
+    pub fn set_channel(&mut self, channel: Channel) {
+        self.disable();
+
+        // NOTE(unsafe) radio is currently disabled
+        unsafe {
+            self.radio
+                .frequency
+                .write(|w| w.map().clear_bit().frequency().bits(channel as u8))
+        }
+    }
+
+    /// Changes the Clear Channel Assessment method
+    pub fn set_cca(&mut self, cca: Cca) {
+        self.disable();
+
+        match cca {
+            Cca::CarrierSense => self.radio.ccactrl.write(|w| w.ccamode().carrier_mode()),
+        }
+    }
+
+    /// Recevies one radio packet and copies its contents into the given `packet` buffer
+    pub fn recv(&mut self, packet: &mut Packet) {
+        // go to the RXIDLE state
+        self.enable_rx();
+
+        // NOTE(unsafe) DMA transfer has not yet started
+        // set up RX buffer
+        unsafe {
+            self.radio
+                .packetptr
+                .write(|w| w.packetptr().bits(packet.buffer.as_mut_ptr() as u32));
+        }
+
+        // start transfer
+        dma_start_fence();
+        self.radio.tasks_start.write(|w| w.tasks_start().set_bit());
+
+        // wait until we have received something
+        self.wait_for_event(Event::End);
+        dma_end_fence();
+
+        // the CRC is checked by the hardware; nothing else to do
+    }
+
+    /// Sends the given `data` as a single radio packet
+    pub fn send(&mut self, packet: &Packet) {
+        // go to the RXIDLE state
+        self.enable_rx();
+
+        // NOTE the DMA doesn't exactly start at this point but due to shortcuts it may occur at any
+        // point after this volatile write
+        dma_start_fence();
+        // NOTE(unsafe) DMA transfer has not yet started
+        unsafe {
+            self.radio
+                .packetptr
+                .write(|w| w.packetptr().bits(packet.buffer.as_ptr() as u32));
+        }
+
+        // start CCA
+        'cca: loop {
+            self.radio
+                .tasks_ccastart
+                .write(|w| w.tasks_ccastart().set_bit());
+
+            loop {
+                if self
+                    .radio
+                    .events_ccaidle
+                    .read()
+                    .events_ccaidle()
+                    .bit_is_set()
+                {
+                    // channel is clear
+                    self.radio.events_ccaidle.reset();
+                    break 'cca;
+                }
+
+                if self
+                    .radio
+                    .events_ccabusy
+                    .read()
+                    .events_ccabusy()
+                    .bit_is_set()
+                {
+                    // channel is busy
+                    self.radio.events_ccaidle.reset();
+                    // FIXME according to the IEEE spec there should be a backoff delay before
+                    // the next CCA
+                    continue 'cca;
+                }
+            }
+        }
+
+        // due to a shortcut the transmission will start automatically so we just have to wait
+        // until the END event
+        self.wait_for_event(Event::End);
+        dma_end_fence();
+    }
+
+    /// Moves the radio from any state to the DISABLED state
+    fn disable(&mut self) {
+        // See figure 110 in nRF52840-PS
+        loop {
+            if let Variant::Val(state) = self.radio.state.read().state().variant() {
+                match state {
+                    STATE_A::DISABLED => return,
+
+                    STATE_A::RXRU | STATE_A::RXIDLE | STATE_A::TXRU | STATE_A::TXIDLE => {
+                        self.radio
+                            .tasks_disable
+                            .write(|w| w.tasks_disable().set_bit());
+
+                        self.wait_for_state(STATE_A::DISABLED);
+                        return;
+                    }
+
+                    // ramping down
+                    STATE_A::RXDISABLE | STATE_A::TXDISABLE => {
+                        self.wait_for_state(STATE_A::DISABLED);
+                        return;
+                    }
+
+                    // cancel ongoing transfer
+                    STATE_A::RX => {
+                        self.radio.tasks_stop.write(|w| w.tasks_stop().set_bit());
+                        self.wait_for_state(STATE_A::RXIDLE);
+                    }
+                    STATE_A::TX => {
+                        self.radio.tasks_stop.write(|w| w.tasks_stop().set_bit());
+                        self.wait_for_state(STATE_A::TXIDLE);
+                    }
+                }
+            } else {
+                // STATE register is in an invalid state
+                unreachable!()
+            }
+        }
+    }
+
+    /// Moves the radio from any state to the RXEN state
+    fn enable_rx(&mut self) {
+        // See figure 110 in nRF52840-PS
+        loop {
+            if let Variant::Val(state) = self.radio.state.read().state().variant() {
+                match state {
+                    STATE_A::RXIDLE => return,
+
+                    STATE_A::DISABLED => {
+                        self.radio.tasks_rxen.write(|w| w.tasks_rxen().set_bit());
+                        self.wait_for_state(STATE_A::RXIDLE);
+                        return;
+                    }
+
+                    // ramping up
+                    STATE_A::RXRU => {
+                        self.wait_for_state(STATE_A::RXIDLE);
+                        return;
+                    }
+
+                    // NOTE to avoid errata 204 (see rev1 v1.4) we first go to the DISABLED state
+                    STATE_A::TXIDLE | STATE_A::TXRU => {
+                        self.radio
+                            .tasks_disable
+                            .write(|w| w.tasks_disable().set_bit());
+                        self.wait_for_state(STATE_A::DISABLED);
+                    }
+
+                    // ramping down
+                    STATE_A::RXDISABLE | STATE_A::TXDISABLE => {
+                        self.wait_for_state(STATE_A::DISABLED);
+                    }
+
+                    // cancel ongoing transfer
+                    STATE_A::RX => {
+                        self.radio.tasks_stop.write(|w| w.tasks_stop().set_bit());
+                        self.wait_for_state(STATE_A::RXIDLE);
+                        return;
+                    }
+                    STATE_A::TX => {
+                        self.radio.tasks_stop.write(|w| w.tasks_stop().set_bit());
+                        self.wait_for_state(STATE_A::TXIDLE);
+                    }
+                }
+            } else {
+                // STATE register is in an invalid state
+                unreachable!()
+            }
+        }
+    }
+
+    fn wait_for_event(&self, event: Event) {
+        match event {
+            Event::End => {
+                while self.radio.events_end.read().events_end().bit_is_clear() {
+                    continue;
+                }
+                self.radio.events_end.reset();
+            }
+        }
+    }
+
+    /// Waits until the radio state matches the given `state`
+    fn wait_for_state(&self, state: STATE_A) {
+        while self.radio.state.read().state() != state {
+            continue;
+        }
+    }
+}
+
+/// NOTE must be followed by a volatile write operation
+fn dma_start_fence() {
+    atomic::compiler_fence(Ordering::Release);
+}
+
+/// NOTE must be preceded by a volatile read operation
+fn dma_end_fence() {
+    atomic::compiler_fence(Ordering::Acquire);
+}
+
+enum Event {
+    End,
+}
+
+/// An IEEE 802.15.4 packet
+pub struct Packet {
+    buffer: [u8; Self::SIZE],
+}
+
+// See figure 124 in nRF52840-PS
+impl Packet {
+    const PHY_HDR: usize = 0;
+    const DATA: RangeFrom<usize> = 1..;
+    // TODO add API to extract the LQI (Link Quality Indicator)
+    const SIZE: usize = 1 /* PHY_HDR */ + Self::MAX_LEN as usize + 1 /* LQI */;
+
+    /// The maximum length of a packet
+    pub const MAX_LEN: u8 = 127;
+
+    /// Returns an empty packe
+    pub fn new() -> Self {
+        Self {
+            buffer: [0; Self::SIZE],
+        }
+    }
+
+    /// Fills the packet with given `src` data
+    ///
+    /// NOTE `src` data will be truncated to `MAX_PACKET_SIZE` bytes
+    pub fn copy_from_slice(&mut self, src: &[u8]) {
+        let len = cmp::min(src.len(), Self::MAX_LEN as usize) as u8;
+        self.buffer[Self::DATA][..len as usize].copy_from_slice(src);
+        self.buffer[Self::PHY_HDR] = len;
+    }
+
+    /// Returns the size of this packet
+    pub fn len(&self) -> u8 {
+        self.buffer[Self::PHY_HDR]
+    }
+
+    /// Changes the `len` of the packet
+    ///
+    /// NOTE `len` will be truncated to `MAX_PACKET_SIZE` bytes
+    pub fn set_len(&mut self, len: u8) {
+        let len = cmp::min(len, Self::MAX_LEN);
+        self.buffer[Self::PHY_HDR] = len;
+    }
+}
+
+impl ops::Deref for Packet {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.buffer[Self::DATA][..self.len() as usize]
+    }
+}
+
+impl ops::DerefMut for Packet {
+    fn deref_mut(&mut self) -> &mut [u8] {
+        let len = self.len();
+        &mut self.buffer[Self::DATA][..len as usize]
+    }
+}

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -18,3 +18,5 @@ pub use crate::spim::Spim;
 pub use crate::temp::Temp;
 pub use crate::timer::Timer;
 pub use crate::uarte::Uarte;
+
+pub mod ieee802154;


### PR DESCRIPTION
what the title says

this PR adds an `ieee802154::Radio` API that wraps the `RADIO` peripheral and puts it in IEEE 802.15.4 mode.

I haven't checked the silicon erratas of (or tested) other chips (the code contains one workaround for (nRF52840 specific?) silicon errata) so for now I have put the API directly under `nrf52840-hal`. But I guess the API should also work on other nRF52 devices -- I think the nRF51 chips do not have an 802.15.4 mode? And I don't know about other chip families.

The implementation is not super IEEE compliant. It's missing a backoff delay mechanism when doing CCA (Clear Channel Assessment) before transmitting packets and it's also missing IFS (inter-frame spacing) between consecutive packets (the hardware has some built-in support for this but the PR doesn't expose it). But it is sufficient to send packets around and receive them on other nRF52s running the same implementation, though it would be good to check this against some third party implementation like the DWM1001 or the MRF24J40.

There are some TODOs here and there in terms of additional things the API could expose like changing the transmit power. I'm not sure if all those need to be added before a review though. They could be added as follow up PRs too.

TODO items
- [x] API to change TX power (the default value doesn't go very far, like tens of centimer or so in a noisy 2.4 GHz environment)
- [x] API to change the start of frame delimiter (the default value matches the IEEE spec)
- [x] API to extract the LQI (Link Quality Indicator)
- [x] verify that CRC are being checked. May need to send a malformed packet from a different device (MRF24J40?)
- [x] "The total usable payload (PSDU) is 127 octets, but when CRC is being used, this is reduced to 125 octets of usable payload." -- adjust MAX_LEN accordingly