### PR TITLE
Clean up gpio.rs

### DIFF
--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -77,14 +77,14 @@ where
     pub fn new(spi: T, pins: Pins, frequency: Frequency, mode: Mode) -> Self {
         // Select pins
         spi.pselsck
-            .write(|w| unsafe { w.bits(pins.sck.pin.into()) });
+            .write(|w| unsafe { w.bits(pins.sck.pin().into()) });
 
         // Optional pins
         if let Some(ref pin) = pins.mosi {
-            spi.pselmosi.write(|w| unsafe { w.bits(pin.pin.into()) });
+            spi.pselmosi.write(|w| unsafe { w.bits(pin.pin().into()) });
         }
         if let Some(ref pin) = pins.miso {
-            spi.pselmiso.write(|w| unsafe { w.bits(pin.pin.into()) });
+            spi.pselmiso.write(|w| unsafe { w.bits(pin.pin().into()) });
         }
 
         // Enable SPI instance

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -96,26 +96,26 @@ where
     pub fn new(spim: T, pins: Pins, frequency: Frequency, mode: Mode, orc: u8) -> Self {
         // Select pins
         spim.psel.sck.write(|w| {
-            let w = unsafe { w.pin().bits(pins.sck.pin) };
+            let w = unsafe { w.pin().bits(pins.sck.pin()) };
             #[cfg(any(feature = "52843", feature = "52840"))]
-            let w = w.port().bit(pins.sck.port);
+            let w = w.port().bit(pins.sck.port().bit());
             w.connect().connected()
         });
 
         match pins.mosi {
             Some(mosi) => spim.psel.mosi.write(|w| {
-                let w = unsafe { w.pin().bits(mosi.pin) };
+                let w = unsafe { w.pin().bits(mosi.pin()) };
                 #[cfg(any(feature = "52843", feature = "52840"))]
-                let w = w.port().bit(mosi.port);
+                let w = w.port().bit(mosi.port().bit());
                 w.connect().connected()
             }),
             None => spim.psel.mosi.write(|w| w.connect().disconnected()),
         }
         match pins.miso {
             Some(miso) => spim.psel.miso.write(|w| {
-                let w = unsafe { w.pin().bits(miso.pin) };
+                let w = unsafe { w.pin().bits(miso.pin()) };
                 #[cfg(any(feature = "52843", feature = "52840"))]
-                let w = w.port().bit(miso.port);
+                let w = w.port().bit(miso.port().bit());
                 w.connect().connected()
             }),
             None => spim.psel.miso.write(|w| w.connect().disconnected()),

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -24,7 +24,7 @@ where
         // the pins through the raw peripheral API. All of the following is
         // safe, as we own the pins now and have exclusive access to their
         // registers.
-        for &pin in &[pins.scl.pin, pins.sda.pin] {
+        for &pin in &[pins.scl.pin(), pins.sda.pin()] {
             unsafe { &*GPIO::ptr() }.pin_cnf[pin as usize].write(|w| {
                 w.dir()
                     .input()
@@ -41,9 +41,9 @@ where
 
         // Set pins
         twi.pselscl
-            .write(|w| unsafe { w.bits(pins.scl.pin.into()) });
+            .write(|w| unsafe { w.bits(pins.scl.pin().into()) });
         twi.pselsda
-            .write(|w| unsafe { w.bits(pins.sda.pin.into()) });
+            .write(|w| unsafe { w.bits(pins.sda.pin().into()) });
 
         // Set frequency
         twi.frequency.write(|w| w.frequency().variant(frequency));

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -48,7 +48,7 @@ where
         // the pins through the raw peripheral API. All of the following is
         // safe, as we own the pins now and have exclusive access to their
         // registers.
-        for &pin in &[pins.scl.pin, pins.sda.pin] {
+        for &pin in &[pins.scl.pin(), pins.sda.pin()] {
             unsafe { &*P0::ptr() }.pin_cnf[pin as usize].write(|w| {
                 w.dir()
                     .input()
@@ -65,15 +65,15 @@ where
 
         // Select pins
         twim.psel.scl.write(|w| {
-            let w = unsafe { w.pin().bits(pins.scl.pin) };
+            let w = unsafe { w.pin().bits(pins.scl.pin()) };
             #[cfg(feature = "52840")]
-            let w = w.port().bit(pins.scl.port);
+            let w = w.port().bit(pins.scl.port().bit());
             w.connect().connected()
         });
         twim.psel.sda.write(|w| {
-            let w = unsafe { w.pin().bits(pins.sda.pin) };
+            let w = unsafe { w.pin().bits(pins.sda.pin()) };
             #[cfg(feature = "52840")]
-            let w = w.port().bit(pins.sda.port);
+            let w = w.port().bit(pins.sda.port().bit());
             w.connect().connected()
         });
 

--- a/nrf-hal-common/src/uart.rs
+++ b/nrf-hal-common/src/uart.rs
@@ -28,14 +28,14 @@ where
 
         // Required pins
         uart.pseltxd
-            .write(|w| unsafe { w.bits(pins.txd.pin.into()) });
+            .write(|w| unsafe { w.bits(pins.txd.pin().into()) });
         uart.pselrxd
-            .write(|w| unsafe { w.bits(pins.rxd.pin.into()) });
+            .write(|w| unsafe { w.bits(pins.rxd.pin().into()) });
 
         // Optional pins
         uart.pselcts.write(|w| unsafe {
             if let Some(ref pin) = pins.cts {
-                w.bits(pin.pin.into())
+                w.bits(pin.pin().into())
             } else {
                 // Disconnect
                 w.bits(0xFFFFFFFF)
@@ -44,7 +44,7 @@ where
 
         uart.pselrts.write(|w| unsafe {
             if let Some(ref pin) = pins.rts {
-                w.bits(pin.pin.into())
+                w.bits(pin.pin().into())
             } else {
                 // Disconnect
                 w.bits(0xFFFFFFFF)

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -45,25 +45,25 @@ where
     pub fn new(uarte: T, mut pins: Pins, parity: Parity, baudrate: Baudrate) -> Self {
         // Select pins
         uarte.psel.rxd.write(|w| {
-            let w = unsafe { w.pin().bits(pins.rxd.pin) };
+            let w = unsafe { w.pin().bits(pins.rxd.pin()) };
             #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.rxd.port);
+            let w = w.port().bit(pins.rxd.port().bit());
             w.connect().connected()
         });
         pins.txd.set_high().unwrap();
         uarte.psel.txd.write(|w| {
-            let w = unsafe { w.pin().bits(pins.txd.pin) };
+            let w = unsafe { w.pin().bits(pins.txd.pin()) };
             #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.txd.port);
+            let w = w.port().bit(pins.txd.port().bit());
             w.connect().connected()
         });
 
         // Optional pins
         uarte.psel.cts.write(|w| {
             if let Some(ref pin) = pins.cts {
-                let w = unsafe { w.pin().bits(pin.pin) };
+                let w = unsafe { w.pin().bits(pin.pin()) };
                 #[cfg(any(feature = "52833", feature = "52840"))]
-                let w = w.port().bit(pin.port);
+                let w = w.port().bit(pin.port().bit());
                 w.connect().connected()
             } else {
                 w.connect().disconnected()
@@ -72,9 +72,9 @@ where
 
         uarte.psel.rts.write(|w| {
             if let Some(ref pin) = pins.rts {
-                let w = unsafe { w.pin().bits(pin.pin) };
+                let w = unsafe { w.pin().bits(pin.pin()) };
                 #[cfg(any(feature = "52833", feature = "52840"))]
-                let w = w.port().bit(pin.port);
+                let w = w.port().bit(pin.port().bit());
                 w.connect().connected()
             } else {
                 w.connect().disconnected()


### PR DESCRIPTION
Fixes #146

This compacts the generic `Pin` struct to a single byte on all MCUs, encoding the port in the upper bit.

Breaking change.