### PR TITLE
Release the pins held by comm drivers

### DIFF
--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -13,7 +13,7 @@ pub use embedded_hal::{
 pub use spi0::frequency::FREQUENCY_A as Frequency;
 
 /// Interface to a SPI instance
-pub struct Spi<T>(T);
+pub struct Spi<T>(T, Pins);
 
 /// Default implementation
 impl<T> write::Default<u8> for Spi<T>
@@ -101,12 +101,12 @@ where
         // Configure frequency
         spi.frequency.write(|w| w.frequency().variant(frequency));
 
-        Self(spi)
+        Self(spi, pins)
     }
 
-    /// Return the raw interface to the underlying SPI peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -32,7 +32,7 @@ use embedded_hal::digital::v2::OutputPin;
 /// - The SPIM instances share the same address space with instances of SPIS,
 ///   SPI, TWIM, TWIS, and TWI. You need to make sure that conflicting instances
 ///   are disabled before using `Spim`. See product specification, section 15.2.
-pub struct Spim<T>(T);
+pub struct Spim<T>(T, Pins);
 
 impl<T> embedded_hal::blocking::spi::Transfer<u8> for Spim<T>
 where
@@ -156,7 +156,7 @@ where
             // there.
             unsafe { w.orc().bits(orc) });
 
-        Spim(spim)
+        Self(spim, pins)
     }
 
     /// Internal helper function to setup and execute SPIM DMA transfer
@@ -372,9 +372,9 @@ where
         self.transfer_split_uneven(chip_select, tx_buffer, &mut [0u8; 0])
     }
 
-    /// Return the raw interface to the underlying SPIM peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -103,7 +103,7 @@ where
         });
 
         match pins.mosi {
-            Some(mosi) => spim.psel.mosi.write(|w| {
+            Some(ref mosi) => spim.psel.mosi.write(|w| {
                 let w = unsafe { w.pin().bits(mosi.pin()) };
                 #[cfg(any(feature = "52843", feature = "52840"))]
                 let w = w.port().bit(mosi.port().bit());
@@ -112,7 +112,7 @@ where
             None => spim.psel.mosi.write(|w| w.connect().disconnected()),
         }
         match pins.miso {
-            Some(miso) => spim.psel.miso.write(|w| {
+            Some(ref miso) => spim.psel.miso.write(|w| {
                 let w = unsafe { w.pin().bits(miso.pin()) };
                 #[cfg(any(feature = "52843", feature = "52840"))]
                 let w = w.port().bit(miso.port().bit());

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -9,7 +9,7 @@ use crate::{
 
 pub use twi0::frequency::FREQUENCY_A as Frequency;
 
-pub struct Twi<T>(T);
+pub struct Twi<T>(T, Pins);
 
 impl<T> Twi<T>
 where
@@ -50,7 +50,7 @@ where
 
         twi.enable.write(|w| w.enable().enabled());
 
-        Self(twi)
+        Self(twi, pins)
     }
 
     fn send_byte(&self, byte: u8) -> Result<(), Error> {
@@ -234,9 +234,9 @@ where
         Ok(())
     }
 
-    /// Return the raw interface to the underlying TWI peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -33,7 +33,7 @@ pub use twim0::frequency::FREQUENCY_A as Frequency;
 /// conflicting instances are disabled before using `Twim`. Please refer to the
 /// product specification for more information (section 15.2 for nRF52832,
 /// section 6.1.2 for nRF52840).
-pub struct Twim<T>(T);
+pub struct Twim<T>(T, Pins);
 
 impl<T> Twim<T>
 where
@@ -83,7 +83,7 @@ where
         // Configure frequency
         twim.frequency.write(|w| w.frequency().variant(frequency));
 
-        Twim(twim)
+        Self(twim, pins)
     }
 
     /// Write to an I2C slave
@@ -333,9 +333,9 @@ where
         Ok(())
     }
 
-    /// Return the raw interface to the underlying TWIM peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 

--- a/nrf-hal-common/src/uart.rs
+++ b/nrf-hal-common/src/uart.rs
@@ -13,7 +13,7 @@ use crate::target::{uart0, UART0};
 pub use uart0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity};
 
 /// Interface to a UART instance
-pub struct Uart<T>(T);
+pub struct Uart<T>(T, Pins);
 
 #[derive(Debug)]
 pub enum Error {}
@@ -66,12 +66,12 @@ where
         uart.tasks_starttx.write(|w| unsafe { w.bits(1) });
         uart.tasks_startrx.write(|w| unsafe { w.bits(1) });
 
-        Uart(uart)
+        Self(uart, pins)
     }
 
-    /// Return the raw interface to the underlying UARTE peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -36,7 +36,7 @@ pub use uarte0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity};
 ///   are disabled before using `Uarte`. See product specification:
 ///     - nrf52832: Section 15.2
 ///     - nrf52840: Section 6.1.2
-pub struct Uarte<T>(T);
+pub struct Uarte<T>(T, Pins);
 
 impl<T> Uarte<T>
 where
@@ -93,7 +93,7 @@ where
         // Configure frequency
         uarte.baudrate.write(|w| w.baudrate().variant(baudrate));
 
-        Uarte(uarte)
+        Self(uarte, pins)
     }
 
     /// Write via UARTE
@@ -328,9 +328,9 @@ where
         // The event flag itself is later reset by `finalize_read`.
     }
 
-    /// Return the raw interface to the underlying UARTE peripheral
-    pub fn free(self) -> T {
-        self.0
+    /// Release the resources held by this object
+    pub fn free(self) -> (T, Pins) {
+        (self.0, self.1)
     }
 }
 


### PR DESCRIPTION
As an alternative, if this causes excess amount of memory usage, the peripherials hold the pin numbers that could be used to conjure up the pins on release.

This is a breaking change for anyone who uses `free()`

Closes #94