### PR TITLE
Fix incorrect logic in transfer_split_uneven

### DIFF
--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -340,7 +340,7 @@ where
         // Don't return early, as we must reset the CS pin
         let res = txi
             .zip(rxi)
-            .take_while(|(t, r)| t.is_some() && r.is_some())
+            .take_while(|(t, r)| t.is_some() || r.is_some())
             // We also turn the slices into either a DmaSlice (if there was data), or a null
             // DmaSlice (if there is no data)
             .map(|(t, r)| {


### PR DESCRIPTION
This seems to be a classic case of comment vs code. Both iterators are finished if both of them return None, not one of them.

Maybe Closes #156