### PR TITLE
Twim: Implicitly copy buffer into RAM if needed when using embedded hal traits

### DIFF
--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -70,6 +70,8 @@ pub mod target_constants {
     pub const SRAM_LOWER: usize = 0x2000_0000;
     pub const SRAM_UPPER: usize = 0x3000_0000;
     pub const FORCE_COPY_BUFFER_SIZE: usize = 255;
+    const _CHECK_FORCE_COPY_BUFFER_SIZE: usize = EASY_DMA_SIZE - FORCE_COPY_BUFFER_SIZE;
+    // ERROR: FORCE_COPY_BUFFER_SIZE must be <= EASY_DMA_SIZE
 }
 #[cfg(any(feature = "52840", feature = "52833", feature = "9160"))]
 pub mod target_constants {
@@ -79,6 +81,8 @@ pub mod target_constants {
     pub const SRAM_LOWER: usize = 0x2000_0000;
     pub const SRAM_UPPER: usize = 0x3000_0000;
     pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
+    const _CHECK_FORCE_COPY_BUFFER_SIZE: usize = EASY_DMA_SIZE - FORCE_COPY_BUFFER_SIZE;
+    // ERROR: FORCE_COPY_BUFFER_SIZE must be <= EASY_DMA_SIZE
 }
 
 /// Does this slice reside entirely within RAM?

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -41,24 +41,13 @@ where
     type Error = Error;
 
     fn transfer<'w>(&mut self, words: &'w mut [u8]) -> Result<&'w [u8], Error> {
-        if slice_in_ram(words) {
-            words.chunks(EASY_DMA_SIZE).try_for_each(|chunk| {
-                self.do_spi_dma_transfer(DmaSlice::from_slice(chunk), DmaSlice::from_slice(chunk))
-            })?;
-        } else {
-            words
-                .chunks_mut(FORCE_COPY_BUFFER_SIZE)
-                .try_for_each(|chunk| {
-                    let mut buf = [0u8; FORCE_COPY_BUFFER_SIZE];
-                    buf[..chunk.len()].copy_from_slice(chunk);
-                    self.do_spi_dma_transfer(
-                        DmaSlice::from_slice(&buf[..chunk.len()]),
-                        DmaSlice::from_slice(&buf[..chunk.len()]),
-                    )?;
-                    chunk.copy_from_slice(&buf[..chunk.len()]);
-                    Ok(())
-                })?;
-        }
+        // If the slice isn't in RAM, we can't write back to it at all
+        slice_in_ram_or(words, Error::DMABufferNotInDataMemory)?;
+
+        words.chunks(EASY_DMA_SIZE).try_for_each(|chunk| {
+            self.do_spi_dma_transfer(DmaSlice::from_slice(chunk), DmaSlice::from_slice(chunk))
+        })?;
+
         Ok(words)
     }
 }

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -380,9 +380,9 @@ where
             unsafe { w.maxcnt().bits(rx_buffer.len() as _) });
 
         // Chunk write data
-        for chunk in tx_buffer.chunks(FORCE_COPY_BUFFER_SIZE) {
+        let wr_buffer = &mut [0; FORCE_COPY_BUFFER_SIZE][..];
+        for chunk in tx_buffer.chunks(FORCE_COPY_BUFFER_SIZE.min(EASY_DMA_SIZE)) {
             // Copy chunk into RAM
-            let wr_buffer = &mut [0; FORCE_COPY_BUFFER_SIZE][..];
             wr_buffer[..chunk.len()].copy_from_slice(chunk);
 
             // Set up the DMA write

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -18,8 +18,7 @@ use crate::target::TWIM1;
 
 use crate::{
     gpio::{Floating, Input, Pin},
-    slice_in_ram_or,
-    slice_in_ram,
+    slice_in_ram, slice_in_ram_or,
     target_constants::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE},
 };
 
@@ -349,10 +348,9 @@ where
     type Error = Error;
 
     fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Error> {
-        if slice_in_ram(bytes){
+        if slice_in_ram(bytes) {
             self.write(addr, bytes)
-        }
-        else {
+        } else {
             let buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..];
             for chunk in bytes.chunks(FORCE_COPY_BUFFER_SIZE) {
                 buf[..chunk.len()].copy_from_slice(chunk);
@@ -386,7 +384,7 @@ where
         bytes: &'w [u8],
         buffer: &'w mut [u8],
     ) -> Result<(), Error> {
-        if slice_in_ram(bytes){
+        if slice_in_ram(bytes) {
             self.write_then_read(addr, bytes, buffer)
         } else {
             let txi = bytes.chunks(FORCE_COPY_BUFFER_SIZE);

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -381,7 +381,7 @@ where
 
         // Chunk write data
         let wr_buffer = &mut [0; FORCE_COPY_BUFFER_SIZE][..];
-        for chunk in tx_buffer.chunks(FORCE_COPY_BUFFER_SIZE.min(EASY_DMA_SIZE)) {
+        for chunk in tx_buffer.chunks(FORCE_COPY_BUFFER_SIZE) {
             // Copy chunk into RAM
             wr_buffer[..chunk.len()].copy_from_slice(chunk);
 


### PR DESCRIPTION
Issue #150 