### PR TITLE
Add Gpiote module (open for feedback)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
   "examples/ecb-demo",
   "examples/ccm-demo",
   "examples/ppi-demo",
+  "examples/gpiote-demo",
 ]
 
 [profile.dev]

--- a/examples/gpiote-demo/Cargo.toml
+++ b/examples/gpiote-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gpiote-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { version = "0.10", features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/gpiote-demo/Embed.toml
+++ b/examples/gpiote-demo/Embed.toml
@@ -1,0 +1,46 @@
+[probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -50,7 +50,11 @@ const APP: () = {
         gpiote.port().enable_interrupt();
 
         // PPI usage, channel 2 event triggers "task out" (toggle) on channel 1 (toggles led1)
-        gpiote.channel(1).output_pin(&led1).task_out_polarity(TaskOutPolarity::Toggle).init_high();
+        gpiote
+            .channel(1)
+            .output_pin(&led1)
+            .task_out_polarity(TaskOutPolarity::Toggle)
+            .init_high();
         gpiote.channel(2).input_pin(&btn2).hi_to_lo(false);
         let ppi_channels = ppi::Parts::new(ctx.device.PPI);
         let mut channel0 = ppi_channels.ppi0;
@@ -100,8 +104,12 @@ const APP: () = {
             // Manually run "task out" (toggle) on channel 1 (toggles led1)
             ctx.resources.gpiote.channel(1).out();
         }
-        if btn3_pressed { rprintln!("Button 3 was pressed!"); }
-        if btn4_pressed { rprintln!("Button 4 was pressed!"); }
+        if btn3_pressed {
+            rprintln!("Button 3 was pressed!");
+        }
+        if btn4_pressed {
+            rprintln!("Button 4 was pressed!");
+        }
     }
 
     extern "C" {

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -51,7 +51,7 @@ const APP: () = {
         // PPI usage, channel 2 event triggers "task out" (toggle) on channel 1 (toggles led1)
         gpiote
             .channel1()
-            .output_pin(&led1)
+            .output_pin(led1)
             .task_out_polarity(TaskOutPolarity::Toggle)
             .init_high();
         gpiote.channel2().input_pin(&btn2).hi_to_lo(false);

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -40,7 +40,11 @@ const APP: () = {
         let gpiote = Gpiote::new(ctx.device.GPIOTE);
 
         // Set btn1 to generate event on channel 0 and enable interrupt
-        gpiote.channel0().input_pin(&btn1).hi_to_lo(true);
+        gpiote
+            .channel0()
+            .input_pin(&btn1)
+            .hi_to_lo()
+            .enable_interrupt();
 
         // Set both btn3 & btn4 to generate port event
         gpiote.port().input_pin(&btn3).low();
@@ -54,7 +58,7 @@ const APP: () = {
             .output_pin(led1)
             .task_out_polarity(TaskOutPolarity::Toggle)
             .init_high();
-        gpiote.channel2().input_pin(&btn2).hi_to_lo(false);
+        gpiote.channel2().input_pin(&btn2).hi_to_lo();
         let ppi_channels = ppi::Parts::new(ctx.device.PPI);
         let mut channel0 = ppi_channels.ppi0;
         channel0.set_task_endpoint(gpiote.channel1().task_out());

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -88,6 +88,12 @@ const APP: () = {
 
     #[task(binds = GPIOTE, resources = [gpiote], schedule = [debounce])]
     fn on_gpiote(ctx: on_gpiote::Context) {
+        if ctx.resources.gpiote.channel0().is_event_triggered() {
+            rprintln!("Interrupt from channel 0 event");
+        }
+        if ctx.resources.gpiote.port().is_event_triggered() {
+            rprintln!("Interrupt from port event");
+        }
         // Reset all events
         ctx.resources.gpiote.reset_events();
         // Debounce

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -52,7 +52,7 @@ const APP: () = {
         // Enable interrupt for port event
         gpiote.port().enable_interrupt();
 
-        // PPI usage, channel 2 event triggers "task out" (toggle) on channel 1 (toggles led1)
+        // PPI usage, channel 2 event triggers "task out" operation (toggle) on channel 1 (toggles led1)
         gpiote
             .channel1()
             .output_pin(led1)
@@ -60,10 +60,10 @@ const APP: () = {
             .init_high();
         gpiote.channel2().input_pin(&btn2).hi_to_lo();
         let ppi_channels = ppi::Parts::new(ctx.device.PPI);
-        let mut channel0 = ppi_channels.ppi0;
-        channel0.set_task_endpoint(gpiote.channel1().task_out());
-        channel0.set_event_endpoint(gpiote.channel2().event());
-        channel0.enable();
+        let mut ppi0 = ppi_channels.ppi0;
+        ppi0.set_task_endpoint(gpiote.channel1().task_out());
+        ppi0.set_event_endpoint(gpiote.channel2().event());
+        ppi0.enable();
 
         // Enable the monotonic timer (CYCCNT)
         ctx.core.DCB.enable_trace();
@@ -108,14 +108,18 @@ const APP: () = {
 
         if btn1_pressed {
             rprintln!("Button 1 was pressed!");
-            // Manually run "task out" (toggle) on channel 1 (toggles led1)
+            // Manually run "task out" operation (toggle) on channel 1 (toggles led1)
             ctx.resources.gpiote.channel1().out();
         }
         if btn3_pressed {
             rprintln!("Button 3 was pressed!");
+            // Manually run "task clear" on channel 1 (led1 on)
+            ctx.resources.gpiote.channel1().clear();
         }
         if btn4_pressed {
             rprintln!("Button 4 was pressed!");
+            // Manually run "task set" on channel 1 (led1 off)
+            ctx.resources.gpiote.channel1().set();
         }
     }
 

--- a/examples/gpiote-demo/src/main.rs
+++ b/examples/gpiote-demo/src/main.rs
@@ -1,0 +1,120 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::InputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::{
+        gpio::{Input, Level, Pin, PullUp},
+        gpiote::*,
+        ppi::{self, ConfigurablePpi, Ppi},
+    },
+    nrf52840_hal as hal,
+    rtic::cyccnt::U32Ext,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
+const APP: () = {
+    struct Resources {
+        gpiote: Gpiote,
+        btn1: Pin<Input<PullUp>>,
+        btn2: Pin<Input<PullUp>>,
+        btn3: Pin<Input<PullUp>>,
+        btn4: Pin<Input<PullUp>>,
+    }
+
+    #[init]
+    fn init(mut ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        rtt_init_print!();
+        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let btn1 = p0.p0_11.into_pullup_input().degrade();
+        let btn2 = p0.p0_12.into_pullup_input().degrade();
+        let btn3 = p0.p0_24.into_pullup_input().degrade();
+        let btn4 = p0.p0_25.into_pullup_input().degrade();
+        let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
+
+        let gpiote = Gpiote::new(ctx.device.GPIOTE);
+
+        // Set btn1 to generate event on channel 0 and enable interrupt
+        gpiote.channel(0).input_pin(&btn1).hi_to_lo(true);
+
+        // Set both btn3 & btn4 to generate port event
+        gpiote.port().input_pin(&btn3).low();
+        gpiote.port().input_pin(&btn4).low();
+        // Enable interrupt for port event
+        gpiote.port().enable_interrupt();
+
+        // PPI usage, channel 2 event triggers "task out" (toggle) on channel 1 (toggles led1)
+        gpiote.channel(1).output_pin(&led1).task_out_polarity(TaskOutPolarity::Toggle).init_high();
+        gpiote.channel(2).input_pin(&btn2).hi_to_lo(false);
+        let ppi_channels = ppi::Parts::new(ctx.device.PPI);
+        let mut channel0 = ppi_channels.ppi0;
+        channel0.set_task_endpoint(gpiote.channel(1).task_out());
+        channel0.set_event_endpoint(gpiote.channel(2).event());
+        channel0.enable();
+
+        // Enable the monotonic timer (CYCCNT)
+        ctx.core.DCB.enable_trace();
+        ctx.core.DWT.enable_cycle_counter();
+
+        rprintln!("Press a button");
+
+        init::LateResources {
+            gpiote,
+            btn1,
+            btn2,
+            btn3,
+            btn4,
+        }
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        loop {
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(binds = GPIOTE, resources = [gpiote], schedule = [debounce])]
+    fn on_gpiote(ctx: on_gpiote::Context) {
+        // Reset all events
+        ctx.resources.gpiote.reset_events();
+        // Debounce
+        ctx.schedule.debounce(ctx.start + 3_000_000.cycles()).ok();
+    }
+
+    #[task(resources = [gpiote, btn1, btn2, btn3, btn4])]
+    fn debounce(ctx: debounce::Context) {
+        let btn1_pressed = ctx.resources.btn1.is_low().unwrap();
+        let btn2_pressed = ctx.resources.btn2.is_low().unwrap();
+        let btn3_pressed = ctx.resources.btn3.is_low().unwrap();
+        let btn4_pressed = ctx.resources.btn4.is_low().unwrap();
+
+        if btn1_pressed {
+            rprintln!("Button 1 was pressed!");
+            // Manually run "task out" (toggle) on channel 1 (toggles led1)
+            ctx.resources.gpiote.channel(1).out();
+        }
+        if btn3_pressed { rprintln!("Button 3 was pressed!"); }
+        if btn4_pressed { rprintln!("Button 4 was pressed!"); }
+    }
+
+    extern "C" {
+        fn SWI0_EGU0();
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -98,7 +98,7 @@ impl<'a> GpioteChannel<'_> {
         }
     }
 
-    pub fn output_pin<P: GpioteOutputPin>(&'a self, pin: &'a P) -> GpioteTask<'a, P> {
+    pub fn output_pin<P: GpioteOutputPin>(&'a self, pin: P) -> GpioteTask<'a, P> {
         GpioteTask {
             gpiote: &self.gpiote,
             pin: pin,
@@ -274,7 +274,7 @@ fn config_port_event_pin<P: GpioteInputPin>(pin: &P, sense: PortEventSense) {
 
 pub struct GpioteTask<'a, P: GpioteOutputPin> {
     gpiote: &'a GPIOTE,
-    pin: &'a P,
+    pin: P,
     channel: usize,
     task_out_polarity: TaskOutPolarity,
 }
@@ -284,7 +284,7 @@ impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
         config_channel_task_pin(
             self.gpiote,
             self.channel,
-            self.pin,
+            &self.pin,
             &self.task_out_polarity,
             Level::High,
         );
@@ -294,7 +294,7 @@ impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
         config_channel_task_pin(
             self.gpiote,
             self.channel,
-            self.pin,
+            &self.pin,
             &self.task_out_polarity,
             Level::Low,
         );

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -1,3 +1,7 @@
+//! HAL interface for the GPIOTE peripheral
+//!
+//! The GPIO tasks and events (GPIOTE) module provides functionality for accessing GPIO pins using tasks and events.
+
 #[cfg(feature = "51")]
 use crate::target::{gpio, GPIO as P0};
 
@@ -23,11 +27,13 @@ const NUM_CHANNELS: usize = 8;
 #[cfg(feature = "51")]
 const NUM_CHANNELS: usize = 4;
 
+/// A safe wrapper around the GPIOTE peripheral.
 pub struct Gpiote {
     gpiote: GPIOTE,
 }
 
 impl Gpiote {
+    /// Takes ownership of the `GPIOTE` peripheral, returning a safe wrapper.
     pub fn new(gpiote: GPIOTE) -> Self {
         Self { gpiote }
     }
@@ -73,12 +79,13 @@ impl Gpiote {
         }
     }
 
+    /// Marks all GPIOTE events as handled
     pub fn reset_events(&self) {
-        // Mark all events as handled
         (0..NUM_CHANNELS).for_each(|ch| self.gpiote.events_in[ch].write(|w| w));
         self.gpiote.events_port.write(|w| w);
     }
 
+    /// Consumes `self` and return back the raw `GPIOTE` peripheral.
     pub fn free(self) -> GPIOTE {
         self.gpiote
     }
@@ -90,6 +97,7 @@ pub struct GpioteChannel<'a> {
 }
 
 impl<'a> GpioteChannel<'_> {
+    /// Configures the channel as an event input with associated pin
     pub fn input_pin<P: GpioteInputPin>(&'a self, pin: &'a P) -> GpioteChannelEvent<'a, P> {
         GpioteChannelEvent {
             gpiote: &self.gpiote,
@@ -97,7 +105,7 @@ impl<'a> GpioteChannel<'_> {
             channel: self.channel,
         }
     }
-
+    /// Configures the channel as a task output with associated pin
     pub fn output_pin<P: GpioteOutputPin>(&'a self, pin: P) -> GpioteTask<'a, P> {
         GpioteTask {
             gpiote: &self.gpiote,
@@ -107,47 +115,49 @@ impl<'a> GpioteChannel<'_> {
         }
     }
 
+    /// Checks if the channel event has been triggered
     pub fn is_event_triggered(&self) -> bool {
         self.gpiote.events_in[self.channel].read().bits() != 0
     }
-
+    /// Resets channel events
     pub fn reset_events(&self) {
         self.gpiote.events_in[self.channel].write(|w| w);
     }
 
+    /// Triggers `task out` (as configured with task_out_polarity, defaults to Toggle)
     pub fn out(&self) {
         self.gpiote.tasks_out[self.channel].write(|w| unsafe { w.bits(1) });
     }
-
+    /// Triggers `task set` (set associated pin high)
     #[cfg(not(feature = "51"))]
     pub fn set(&self) {
         self.gpiote.tasks_set[self.channel].write(|w| unsafe { w.bits(1) });
     }
-
+    /// Triggers `task clear` (set associated pin low)
     #[cfg(not(feature = "51"))]
     pub fn clear(&self) {
         self.gpiote.tasks_clr[self.channel].write(|w| unsafe { w.bits(1) });
     }
 
+    /// Returns reference to channel event endpoint for PPI
     pub fn event(&self) -> &Reg<u32, _EVENTS_IN> {
-        // Return reference to event for PPI
         &self.gpiote.events_in[self.channel]
     }
 
+    /// Returns reference to task_out endpoint for PPI
     pub fn task_out(&self) -> &Reg<u32, _TASKS_OUT> {
-        // Return reference to task_out for PPI
         &self.gpiote.tasks_out[self.channel]
     }
 
+    /// Returns reference to task_clr endpoint for PPI
     #[cfg(not(feature = "51"))]
     pub fn task_clr(&self) -> &Reg<u32, _TASKS_CLR> {
-        // Return reference to task_clr for PPI
         &self.gpiote.tasks_clr[self.channel]
     }
 
+    /// Returns reference to task_set endpoint for PPI
     #[cfg(not(feature = "51"))]
     pub fn task_set(&self) -> &Reg<u32, _TASKS_SET> {
-        // Return reference to task_set for PPI
         &self.gpiote.tasks_set[self.channel]
     }
 }
@@ -157,26 +167,28 @@ pub struct GpiotePort<'a> {
 }
 
 impl<'a> GpiotePort<'_> {
+    /// Configures associated pin as port event trigger
     pub fn input_pin<P: GpioteInputPin>(&'a self, pin: &'a P) -> GpiotePortEvent<'a, P> {
         GpiotePortEvent { pin }
     }
+    /// Enables GPIOTE interrupt for port events
     pub fn enable_interrupt(&self) {
-        // Enable port interrupt
         self.gpiote.intenset.write(|w| w.port().set());
     }
+    /// Disables GPIOTE interrupt for port events
     pub fn disable_interrupt(&self) {
-        // Disable port interrupt
         self.gpiote.intenclr.write(|w| w.port().set_bit());
     }
+    /// Checks if port event has been triggered
     pub fn is_event_triggered(&self) -> bool {
         self.gpiote.events_port.read().bits() != 0
     }
+    /// Marks port events as handled
     pub fn reset_events(&self) {
-        // Mark port events as handled
         self.gpiote.events_port.write(|w| w);
     }
+    /// Returns reference to port event endpoint for PPI
     pub fn event(&self) -> &Reg<u32, _EVENTS_PORT> {
-        // Return reference to event for PPI
         &self.gpiote.events_port
     }
 }
@@ -188,28 +200,29 @@ pub struct GpioteChannelEvent<'a, P: GpioteInputPin> {
 }
 
 impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
+    /// Generates event on falling edge
     pub fn hi_to_lo(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::HiToLo);
         self
     }
-
+    /// Generates event on rising edge
     pub fn lo_to_hi(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::LoToHi);
         self
     }
-
+    /// Generates event on any pin activity
     pub fn toggle(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::Toggle);
         self
     }
-
+    /// No event is generated on pin activity
     pub fn none(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::None);
         self
     }
 
+    /// Enables GPIOTE interrupt for pin
     pub fn enable_interrupt(&self) -> &Self {
-        // Enable interrupt for pin
         unsafe {
             self.gpiote
                 .intenset
@@ -218,8 +231,8 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         self
     }
 
+    /// Disables GPIOTE interrupt for pin
     pub fn disable_interrupt(&self) -> &Self {
-        // Disable interrupt for pin
         unsafe {
             self.gpiote
                 .intenclr
@@ -252,12 +265,15 @@ pub struct GpiotePortEvent<'a, P: GpioteInputPin> {
 }
 
 impl<'a, P: GpioteInputPin> GpiotePortEvent<'_, P> {
+    /// Generates event on pin low
     pub fn low(&self) {
         config_port_event_pin(self.pin, PortEventSense::Low);
     }
+    /// Generates event on pin high
     pub fn high(&self) {
         config_port_event_pin(self.pin, PortEventSense::High);
     }
+    /// No event is generated on pin activity
     pub fn disabled(&self) {
         config_port_event_pin(self.pin, PortEventSense::Disabled);
     }
@@ -290,6 +306,7 @@ pub struct GpioteTask<'a, P: GpioteOutputPin> {
 }
 
 impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
+    /// Sets initial task output pin state to high
     pub fn init_high(&self) {
         config_channel_task_pin(
             self.gpiote,
@@ -299,7 +316,7 @@ impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
             Level::High,
         );
     }
-
+    /// Sets initial task output pin state to low
     pub fn init_low(&self) {
         config_channel_task_pin(
             self.gpiote,
@@ -309,7 +326,7 @@ impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
             Level::Low,
         );
     }
-
+    /// Configures polarity of the `task out` operation
     pub fn task_out_polarity(&mut self, polarity: TaskOutPolarity) -> &mut Self {
         self.task_out_polarity = polarity;
         self
@@ -338,6 +355,7 @@ fn config_channel_task_pin<P: GpioteOutputPin>(
     });
 }
 
+/// Polarity of the `task out` operation
 pub enum TaskOutPolarity {
     Set,
     Clear,
@@ -357,6 +375,7 @@ pub enum PortEventSense {
     Low,
 }
 
+/// Trait to represent event input pin
 pub trait GpioteInputPin {
     fn pin(&self) -> u8;
     fn port(&self) -> Port;
@@ -389,6 +408,7 @@ impl GpioteInputPin for Pin<Input<Floating>> {
     }
 }
 
+/// Trait to represent task output pin
 pub trait GpioteOutputPin {
     fn pin(&self) -> u8;
 }

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -32,11 +32,39 @@ impl Gpiote {
         Self { gpiote }
     }
 
-    pub fn channel(&self, channel: usize) -> GpioteChannel {
+    fn channel(&self, channel: usize) -> GpioteChannel {
         GpioteChannel {
             gpiote: &self.gpiote,
             channel,
         }
+    }
+    pub fn channel0(&self) -> GpioteChannel {
+        self.channel(0)
+    }
+    pub fn channel1(&self) -> GpioteChannel {
+        self.channel(1)
+    }
+    pub fn channel2(&self) -> GpioteChannel {
+        self.channel(2)
+    }
+    pub fn channel3(&self) -> GpioteChannel {
+        self.channel(3)
+    }
+    #[cfg(not(feature = "51"))]
+    pub fn channel4(&self) -> GpioteChannel {
+        self.channel(4)
+    }
+    #[cfg(not(feature = "51"))]
+    pub fn channel5(&self) -> GpioteChannel {
+        self.channel(5)
+    }
+    #[cfg(not(feature = "51"))]
+    pub fn channel6(&self) -> GpioteChannel {
+        self.channel(6)
+    }
+    #[cfg(not(feature = "51"))]
+    pub fn channel7(&self) -> GpioteChannel {
+        self.channel(7)
     }
 
     pub fn port(&self) -> GpiotePort {

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -181,41 +181,34 @@ pub struct GpioteChannelEvent<'a, P: GpioteInputPin> {
 }
 
 impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
-    pub fn hi_to_lo(&self, enable_interrupt: bool) {
+    pub fn hi_to_lo(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::HiToLo);
-        if enable_interrupt {
-            self.enable_interrupt();
-        }
+        self
     }
 
-    pub fn lo_to_hi(&self, enable_interrupt: bool) {
+    pub fn lo_to_hi(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::LoToHi);
-        if enable_interrupt {
-            self.enable_interrupt();
-        }
+        self
     }
 
-    pub fn toggle(&self, enable_interrupt: bool) {
+    pub fn toggle(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::Toggle);
-        if enable_interrupt {
-            self.enable_interrupt();
-        }
+        self
     }
 
-    pub fn none(&self, enable_interrupt: bool) {
+    pub fn none(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::None);
-        if enable_interrupt {
-            self.enable_interrupt();
-        }
+        self
     }
 
-    pub fn enable_interrupt(&self) {
+    pub fn enable_interrupt(&self) -> &Self {
         // Enable interrupt for pin
         unsafe {
             self.gpiote
                 .intenset
                 .modify(|r, w| w.bits(r.bits() | self.pin.pin() as u32))
         }
+        self
     }
 }
 

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -157,8 +157,6 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::HiToLo);
         if enable_interrupt {
             self.enable_interrupt();
-        } else {
-            self.disable_interrupt();
         }
     }
 
@@ -166,8 +164,6 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::LoToHi);
         if enable_interrupt {
             self.enable_interrupt();
-        } else {
-            self.disable_interrupt();
         }
     }
 
@@ -175,8 +171,6 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::Toggle);
         if enable_interrupt {
             self.enable_interrupt();
-        } else {
-            self.disable_interrupt();
         }
     }
 
@@ -184,8 +178,6 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::None);
         if enable_interrupt {
             self.enable_interrupt();
-        } else {
-            self.disable_interrupt();
         }
     }
 
@@ -194,15 +186,6 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         unsafe {
             self.gpiote
                 .intenset
-                .modify(|r, w| w.bits(r.bits() | self.pin.pin() as u32))
-        }
-    }
-
-    pub fn disable_interrupt(&self) {
-        // Disable interrupt for pin
-        unsafe {
-            self.gpiote
-                .intenclr
                 .modify(|r, w| w.bits(r.bits() | self.pin.pin() as u32))
         }
     }

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -210,6 +210,16 @@ impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
         }
         self
     }
+
+    pub fn disable_interrupt(&self) -> &Self {
+        // Disable interrupt for pin
+        unsafe {
+            self.gpiote
+                .intenclr
+                .write(|w| w.bits(self.pin.pin() as u32))
+        }
+        self
+    }
 }
 
 fn config_channel_event_pin<P: GpioteInputPin>(

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -1,0 +1,385 @@
+#[cfg(feature = "51")]
+use crate::target::{gpio, GPIO as P0};
+
+#[cfg(not(feature = "51"))]
+use crate::target::{p0 as gpio, P0};
+
+#[cfg(any(feature = "52833", feature = "52840"))]
+use crate::target::P1;
+
+use {
+    crate::gpio::{
+        Floating, Input, Level, OpenDrain, Output, Pin, Port, PullDown, PullUp, PushPull,
+    },
+    crate::target::gpiote::{_EVENTS_IN, _EVENTS_PORT, _TASKS_OUT},
+    crate::target::{generic::Reg, GPIOTE},
+};
+
+#[cfg(not(feature = "51"))]
+use crate::target::gpiote::{_TASKS_CLR, _TASKS_SET};
+
+#[cfg(not(feature = "51"))]
+const NUM_CHANNELS: usize = 8;
+#[cfg(feature = "51")]
+const NUM_CHANNELS: usize = 4;
+
+pub struct Gpiote {
+    gpiote: GPIOTE,
+}
+
+impl Gpiote {
+    pub fn new(gpiote: GPIOTE) -> Self {
+        Self { gpiote }
+    }
+
+    pub fn channel(&self, channel: usize) -> GpioteChannel {
+        GpioteChannel {
+            gpiote: &self.gpiote,
+            channel,
+        }
+    }
+
+    pub fn port(&self) -> GpiotePort {
+        GpiotePort {
+            gpiote: &self.gpiote,
+        }
+    }
+
+    pub fn reset_events(&self) {
+        // Mark all events as handled
+        (0..NUM_CHANNELS).for_each(|ch| self.gpiote.events_in[ch].write(|w| w));
+        self.gpiote.events_port.write(|w| w);
+    }
+
+    pub fn free(self) -> GPIOTE {
+        self.gpiote
+    }
+}
+
+pub struct GpioteChannel<'a> {
+    gpiote: &'a GPIOTE,
+    channel: usize,
+}
+
+impl<'a> GpioteChannel<'_> {
+    pub fn input_pin<P: GpioteInputPin>(&'a self, pin: &'a P) -> GpioteChannelEvent<'a, P> {
+        GpioteChannelEvent {
+            gpiote: &self.gpiote,
+            pin: pin,
+            channel: self.channel,
+        }
+    }
+
+    pub fn output_pin<P: GpioteOutputPin>(&'a self, pin: &'a P) -> GpioteTask<'a, P> {
+        GpioteTask {
+            gpiote: &self.gpiote,
+            pin: pin,
+            channel: self.channel,
+            task_out_polarity: TaskOutPolarity::Toggle,
+        }
+    }
+
+    pub fn reset_events(&self) {
+        self.gpiote.events_in[self.channel].write(|w| w);
+    }
+
+    pub fn out(&self) {
+        self.gpiote.tasks_out[self.channel].write(|w| unsafe { w.bits(1) });
+    }
+
+    #[cfg(not(feature = "51"))]
+    pub fn set(&self) {
+        self.gpiote.tasks_set[self.channel].write(|w| unsafe { w.bits(1) });
+    }
+
+    #[cfg(not(feature = "51"))]
+    pub fn clear(&self) {
+        self.gpiote.tasks_clr[self.channel].write(|w| unsafe { w.bits(1) });
+    }
+
+    pub fn event(&self) -> &Reg<u32, _EVENTS_IN> {
+        // Return reference to event for PPI
+        &self.gpiote.events_in[self.channel]
+    }
+
+    pub fn task_out(&self) -> &Reg<u32, _TASKS_OUT> {
+        // Return reference to task_out for PPI
+        &self.gpiote.tasks_out[self.channel]
+    }
+
+    #[cfg(not(feature = "51"))]
+    pub fn task_clr(&self) -> &Reg<u32, _TASKS_CLR> {
+        // Return reference to task_clr for PPI
+        &self.gpiote.tasks_clr[self.channel]
+    }
+
+    #[cfg(not(feature = "51"))]
+    pub fn task_set(&self) -> &Reg<u32, _TASKS_SET> {
+        // Return reference to task_set for PPI
+        &self.gpiote.tasks_set[self.channel]
+    }
+}
+
+pub struct GpiotePort<'a> {
+    gpiote: &'a GPIOTE,
+}
+
+impl<'a> GpiotePort<'_> {
+    pub fn input_pin<P: GpioteInputPin>(&'a self, pin: &'a P) -> GpiotePortEvent<'a, P> {
+        GpiotePortEvent { pin }
+    }
+    pub fn enable_interrupt(&self) {
+        // Enable port interrupt
+        self.gpiote.intenset.write(|w| w.port().set());
+    }
+    pub fn disable_interrupt(&self) {
+        // Disable port interrupt
+        self.gpiote.intenclr.write(|w| w.port().set_bit());
+    }
+    pub fn reset_events(&self) {
+        // Mark port events as handled
+        self.gpiote.events_port.write(|w| w);
+    }
+    pub fn event(&self) -> &Reg<u32, _EVENTS_PORT> {
+        // Return reference to event for PPI
+        &self.gpiote.events_port
+    }
+}
+
+pub struct GpioteChannelEvent<'a, P: GpioteInputPin> {
+    gpiote: &'a GPIOTE,
+    pin: &'a P,
+    channel: usize,
+}
+
+impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
+    pub fn hi_to_lo(&self, enable_interrupt: bool) {
+        config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::HiToLo);
+        if enable_interrupt {
+            self.enable_interrupt();
+        } else {
+            self.disable_interrupt();
+        }
+    }
+
+    pub fn lo_to_hi(&self, enable_interrupt: bool) {
+        config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::LoToHi);
+        if enable_interrupt {
+            self.enable_interrupt();
+        } else {
+            self.disable_interrupt();
+        }
+    }
+
+    pub fn toggle(&self, enable_interrupt: bool) {
+        config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::Toggle);
+        if enable_interrupt {
+            self.enable_interrupt();
+        } else {
+            self.disable_interrupt();
+        }
+    }
+
+    pub fn none(&self, enable_interrupt: bool) {
+        config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::None);
+        if enable_interrupt {
+            self.enable_interrupt();
+        } else {
+            self.disable_interrupt();
+        }
+    }
+
+    pub fn enable_interrupt(&self) {
+        // Enable interrupt for pin
+        unsafe {
+            self.gpiote
+                .intenset
+                .modify(|r, w| w.bits(r.bits() | self.pin.pin() as u32))
+        }
+    }
+
+    pub fn disable_interrupt(&self) {
+        // Disable interrupt for pin
+        unsafe {
+            self.gpiote
+                .intenclr
+                .modify(|r, w| w.bits(r.bits() | self.pin.pin() as u32))
+        }
+    }
+}
+
+fn config_channel_event_pin<P: GpioteInputPin>(
+    gpiote: &GPIOTE,
+    channel: usize,
+    pin: &P,
+    trigger_mode: EventPolarity,
+) {
+    // Config pin as event-triggering input for specified edge transition trigger mode
+    gpiote.config[channel].write(|w| {
+        match trigger_mode {
+            EventPolarity::HiToLo => w.mode().event().polarity().hi_to_lo(),
+            EventPolarity::LoToHi => w.mode().event().polarity().lo_to_hi(),
+            EventPolarity::None => w.mode().event().polarity().none(),
+            EventPolarity::Toggle => w.mode().event().polarity().toggle(),
+        };
+        unsafe { w.psel().bits(pin.pin()) }
+    });
+}
+
+pub struct GpiotePortEvent<'a, P: GpioteInputPin> {
+    pin: &'a P,
+}
+
+impl<'a, P: GpioteInputPin> GpiotePortEvent<'_, P> {
+    pub fn low(&self) {
+        config_port_event_pin(self.pin, PortEventSense::Low);
+    }
+    pub fn high(&self) {
+        config_port_event_pin(self.pin, PortEventSense::High);
+    }
+    pub fn disabled(&self) {
+        config_port_event_pin(self.pin, PortEventSense::Disabled);
+    }
+}
+
+fn config_port_event_pin<P: GpioteInputPin>(pin: &P, sense: PortEventSense) {
+    // Set pin sense to specified mode to trigger port events
+    unsafe {
+        &(*{
+            match pin.port() {
+                Port::Port0 => P0::ptr(),
+                #[cfg(any(feature = "52833", feature = "52840"))]
+                Port::Port1 => P1::ptr(),
+            }
+        })
+        .pin_cnf[pin.pin() as usize]
+    }
+    .modify(|_r, w| match sense {
+        PortEventSense::Disabled => w.sense().disabled(),
+        PortEventSense::High => w.sense().high(),
+        PortEventSense::Low => w.sense().low(),
+    });
+}
+
+pub struct GpioteTask<'a, P: GpioteOutputPin> {
+    gpiote: &'a GPIOTE,
+    pin: &'a P,
+    channel: usize,
+    task_out_polarity: TaskOutPolarity,
+}
+
+impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
+    pub fn init_high(&self) {
+        config_channel_task_pin(
+            self.gpiote,
+            self.channel,
+            self.pin,
+            &self.task_out_polarity,
+            Level::High,
+        );
+    }
+
+    pub fn init_low(&self) {
+        config_channel_task_pin(
+            self.gpiote,
+            self.channel,
+            self.pin,
+            &self.task_out_polarity,
+            Level::Low,
+        );
+    }
+
+    pub fn task_out_polarity(&mut self, polarity: TaskOutPolarity) -> &mut Self {
+        self.task_out_polarity = polarity;
+        self
+    }
+}
+
+fn config_channel_task_pin<P: GpioteOutputPin>(
+    gpiote: &GPIOTE,
+    channel: usize,
+    pin: &P,
+    task_out_polarity: &TaskOutPolarity,
+    init_out: Level,
+) {
+    // Config pin as task output with specified initial state and task out polarity
+    gpiote.config[channel].write(|w| {
+        match init_out {
+            Level::High => w.mode().task().outinit().high(),
+            Level::Low => w.mode().task().outinit().low(),
+        };
+        match task_out_polarity {
+            TaskOutPolarity::Set => w.polarity().lo_to_hi(),
+            TaskOutPolarity::Clear => w.polarity().hi_to_lo(),
+            TaskOutPolarity::Toggle => w.polarity().toggle(),
+        };
+        unsafe { w.psel().bits(pin.pin()) }
+    });
+}
+
+pub enum TaskOutPolarity {
+    Set,
+    Clear,
+    Toggle,
+}
+
+pub enum EventPolarity {
+    None,
+    HiToLo,
+    LoToHi,
+    Toggle,
+}
+
+pub enum PortEventSense {
+    Disabled,
+    High,
+    Low,
+}
+
+pub trait GpioteInputPin {
+    fn pin(&self) -> u8;
+    fn port(&self) -> Port;
+}
+
+impl GpioteInputPin for Pin<Input<PullUp>> {
+    fn pin(&self) -> u8 {
+        self.pin()
+    }
+    fn port(&self) -> Port {
+        self.port()
+    }
+}
+
+impl GpioteInputPin for Pin<Input<PullDown>> {
+    fn pin(&self) -> u8 {
+        self.pin()
+    }
+    fn port(&self) -> Port {
+        self.port()
+    }
+}
+
+impl GpioteInputPin for Pin<Input<Floating>> {
+    fn pin(&self) -> u8 {
+        self.pin()
+    }
+    fn port(&self) -> Port {
+        self.port()
+    }
+}
+
+pub trait GpioteOutputPin {
+    fn pin(&self) -> u8;
+}
+
+impl GpioteOutputPin for Pin<Output<OpenDrain>> {
+    fn pin(&self) -> u8 {
+        self.pin()
+    }
+}
+
+impl GpioteOutputPin for Pin<Output<PushPull>> {
+    fn pin(&self) -> u8 {
+        self.pin()
+    }
+}

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -107,6 +107,10 @@ impl<'a> GpioteChannel<'_> {
         }
     }
 
+    pub fn is_event_triggered(&self) -> bool {
+        self.gpiote.events_in[self.channel].read().bits() != 0
+    }
+
     pub fn reset_events(&self) {
         self.gpiote.events_in[self.channel].write(|w| w);
     }
@@ -163,6 +167,9 @@ impl<'a> GpiotePort<'_> {
     pub fn disable_interrupt(&self) {
         // Disable port interrupt
         self.gpiote.intenclr.write(|w| w.port().set_bit());
+    }
+    pub fn is_event_triggered(&self) -> bool {
+        self.gpiote.events_port.read().bits() != 0
     }
     pub fn reset_events(&self) {
         // Mark port events as handled

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -31,6 +31,8 @@ pub mod delay;
 pub mod ecb;
 pub mod gpio;
 #[cfg(not(feature = "9160"))]
+pub mod gpiote;
+#[cfg(not(feature = "9160"))]
 pub mod ppi;
 #[cfg(not(feature = "9160"))]
 pub mod rng;

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -124,16 +124,21 @@ where
             // values.
             unsafe { w.maxcnt().bits(buffer.len() as _) });
 
+        // Clear address NACK
+        self.0.errorsrc.write(|w| w.anack().bit(true));
+
         // Start write operation
         self.0.tasks_starttx.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
 
         // Wait until write operation is about to end
-        while self.0.events_lasttx.read().bits() == 0 {}
+        while self.0.events_lasttx.read().bits() == 0
+            && self.0.errorsrc.read().anack().is_not_received()
+        {}
         self.0.events_lasttx.write(|w| w); // reset event
 
-        // Stop read operation
+        // Stop write operation
         self.0.tasks_stop.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
@@ -146,6 +151,10 @@ where
         // take in to account actions by DMA. The fence has been placed here,
         // after all possible DMA actions have completed
         compiler_fence(SeqCst);
+
+        if self.0.errorsrc.read().anack().is_received() {
+            return Err(Error::AddressNack);
+        }
 
         if self.0.txd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Transmit);
@@ -196,13 +205,18 @@ where
             // full range of values that fit in a `u8`.
             unsafe { w.maxcnt().bits(buffer.len() as _) });
 
+        // Clear address NACK
+        self.0.errorsrc.write(|w| w.anack().bit(true));
+
         // Start read operation
         self.0.tasks_startrx.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
 
         // Wait until read operation is about to end
-        while self.0.events_lastrx.read().bits() == 0 {}
+        while self.0.events_lastrx.read().bits() == 0
+            && self.0.errorsrc.read().anack().is_not_received()
+        {}
         self.0.events_lastrx.write(|w| w); // reset event
 
         // Stop read operation
@@ -218,6 +232,10 @@ where
         // take in to account actions by DMA. The fence has been placed here,
         // after all possible DMA actions have completed
         compiler_fence(SeqCst);
+
+        if self.0.errorsrc.read().anack().is_received() {
+            return Err(Error::AddressNack);
+        }
 
         if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Receive);
@@ -297,15 +315,40 @@ where
             // full range of values that fit in a `u8`.
             unsafe { w.maxcnt().bits(rd_buffer.len() as _) });
 
-        // Immediately start RX after TX, then stop
-        self.0
-            .shorts
-            .modify(|_r, w| w.lasttx_startrx().enabled().lastrx_stop().enabled());
+        // Clear address NACK
+        self.0.errorsrc.write(|w| w.anack().bit(true));
 
         // Start write operation
-        self.0.tasks_starttx.write(|w|
+        // `1` is a valid value to write to task registers.
+        self.0.tasks_starttx.write(|w| unsafe { w.bits(1) });
+
+        // Wait until write operation is about to end
+        while self.0.events_lasttx.read().bits() == 0
+            && self.0.errorsrc.read().anack().is_not_received()
+        {}
+        self.0.events_lasttx.write(|w| w); // reset event
+
+        // Stop operation if address is NACK
+        if self.0.errorsrc.read().anack().is_received() {
             // `1` is a valid value to write to task registers.
-            unsafe { w.bits(1) });
+            self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
+            // Wait until operation is stopped
+            while self.0.events_stopped.read().bits() == 0 {}
+            self.0.events_stopped.write(|w| w); // reset event
+            return Err(Error::AddressNack);
+        }
+
+        // Start read operation
+        // `1` is a valid value to write to task registers.
+        self.0.tasks_startrx.write(|w| unsafe { w.bits(1) });
+
+        // Wait until read operation is about to end
+        while self.0.events_lastrx.read().bits() == 0 {}
+        self.0.events_lastrx.write(|w| w); // reset event
+
+        // Stop read operation
+        // `1` is a valid value to write to task registers.
+        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
 
         // Wait until total operation has ended
         while self.0.events_stopped.read().bits() == 0 {}
@@ -313,7 +356,6 @@ where
         self.0.events_lasttx.write(|w| w); // reset event
         self.0.events_lastrx.write(|w| w); // reset event
         self.0.events_stopped.write(|w| w); // reset event
-        self.0.shorts.write(|w| w);
 
         // Conservative compiler fence to prevent optimizations that do not
         // take in to account actions by DMA. The fence has been placed here,
@@ -527,6 +569,7 @@ pub enum Error {
     Transmit,
     Receive,
     DMABufferNotInDataMemory,
+    AddressNack,
 }
 
 /// Implemented by all TWIM instances

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -124,21 +124,16 @@ where
             // values.
             unsafe { w.maxcnt().bits(buffer.len() as _) });
 
-        // Clear address NACK
-        self.0.errorsrc.write(|w| w.anack().bit(true));
-
         // Start write operation
         self.0.tasks_starttx.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
 
         // Wait until write operation is about to end
-        while self.0.events_lasttx.read().bits() == 0
-            && self.0.errorsrc.read().anack().is_not_received()
-        {}
+        while self.0.events_lasttx.read().bits() == 0 {}
         self.0.events_lasttx.write(|w| w); // reset event
 
-        // Stop write operation
+        // Stop read operation
         self.0.tasks_stop.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
@@ -151,10 +146,6 @@ where
         // take in to account actions by DMA. The fence has been placed here,
         // after all possible DMA actions have completed
         compiler_fence(SeqCst);
-
-        if self.0.errorsrc.read().anack().is_received() {
-            return Err(Error::AddressNack);
-        }
 
         if self.0.txd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Transmit);
@@ -205,18 +196,13 @@ where
             // full range of values that fit in a `u8`.
             unsafe { w.maxcnt().bits(buffer.len() as _) });
 
-        // Clear address NACK
-        self.0.errorsrc.write(|w| w.anack().bit(true));
-
         // Start read operation
         self.0.tasks_startrx.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
 
         // Wait until read operation is about to end
-        while self.0.events_lastrx.read().bits() == 0
-            && self.0.errorsrc.read().anack().is_not_received()
-        {}
+        while self.0.events_lastrx.read().bits() == 0 {}
         self.0.events_lastrx.write(|w| w); // reset event
 
         // Stop read operation
@@ -232,10 +218,6 @@ where
         // take in to account actions by DMA. The fence has been placed here,
         // after all possible DMA actions have completed
         compiler_fence(SeqCst);
-
-        if self.0.errorsrc.read().anack().is_received() {
-            return Err(Error::AddressNack);
-        }
 
         if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
             return Err(Error::Receive);
@@ -315,40 +297,15 @@ where
             // full range of values that fit in a `u8`.
             unsafe { w.maxcnt().bits(rd_buffer.len() as _) });
 
-        // Clear address NACK
-        self.0.errorsrc.write(|w| w.anack().bit(true));
+        // Immediately start RX after TX, then stop
+        self.0
+            .shorts
+            .modify(|_r, w| w.lasttx_startrx().enabled().lastrx_stop().enabled());
 
         // Start write operation
-        // `1` is a valid value to write to task registers.
-        self.0.tasks_starttx.write(|w| unsafe { w.bits(1) });
-
-        // Wait until write operation is about to end
-        while self.0.events_lasttx.read().bits() == 0
-            && self.0.errorsrc.read().anack().is_not_received()
-        {}
-        self.0.events_lasttx.write(|w| w); // reset event
-
-        // Stop operation if address is NACK
-        if self.0.errorsrc.read().anack().is_received() {
+        self.0.tasks_starttx.write(|w|
             // `1` is a valid value to write to task registers.
-            self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
-            // Wait until operation is stopped
-            while self.0.events_stopped.read().bits() == 0 {}
-            self.0.events_stopped.write(|w| w); // reset event
-            return Err(Error::AddressNack);
-        }
-
-        // Start read operation
-        // `1` is a valid value to write to task registers.
-        self.0.tasks_startrx.write(|w| unsafe { w.bits(1) });
-
-        // Wait until read operation is about to end
-        while self.0.events_lastrx.read().bits() == 0 {}
-        self.0.events_lastrx.write(|w| w); // reset event
-
-        // Stop read operation
-        // `1` is a valid value to write to task registers.
-        self.0.tasks_stop.write(|w| unsafe { w.bits(1) });
+            unsafe { w.bits(1) });
 
         // Wait until total operation has ended
         while self.0.events_stopped.read().bits() == 0 {}
@@ -356,6 +313,7 @@ where
         self.0.events_lasttx.write(|w| w); // reset event
         self.0.events_lastrx.write(|w| w); // reset event
         self.0.events_stopped.write(|w| w); // reset event
+        self.0.shorts.write(|w| w);
 
         // Conservative compiler fence to prevent optimizations that do not
         // take in to account actions by DMA. The fence has been placed here,
@@ -569,7 +527,6 @@ pub enum Error {
     Transmit,
     Receive,
     DMABufferNotInDataMemory,
-    AddressNack,
 }
 
 /// Implemented by all TWIM instances


### PR DESCRIPTION
Hi nRF team!

Here's a starting point of a Gpiote module, based on how i've been using it in my projects.
Let's discuss a suitable api, at the moment it looks like this:

`let gpiote = gpiote::Gpiote::new(p.GPIOTE);`

Example how to configure an input pin as an event source for channel 0, triggering on hi-to-low transition and firing the GPIO interrupt:
`let btn1 = p0.p0_11.into_pullup_input().degrade();`
`gpiote.channel0().input_pin(&btn1).hi_to_lo().enable_interrupt();`

Or using port event:
`gpiote.port().input_pin(&btn1).low();`
`gpiote.port().input_pin(&btn3).low();`
`gpiote.port().enable_interrupt();`

In the GPIOTE ISR, check for triggered events like:
`gpiote.channel0().is_event_triggered()`
 Reset channel events like:
`gpiote.channel0().reset_events();`
Reset port events like
`gpiote.port().reset_events();`
Or globally reset all events like:
`gpiote.reset_events();`

Task output pins are configured like:
`let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();`
`gpiote.channel1().output_pin(led1).init_high();`

The assigned output pin is consumed because when an output pin is in task mode, it can no longer be used with the normal gpio api, instead you would use the provided task functions `set()`, `clear()` and `out()`.

All configuations available in the registers are implemented aswell as far as i can tell.

Here's a demo using interrupts and PPI with the onboard buttons and leds of the nrf52840-DK:
https://github.com/kalkyl/nrf-hal/blob/gpiote/examples/gpiote-demo/src/main.rs

Cheers!

EDIT: Updated with the latest version of the api