### PR TITLE
Move to 'fixed' crate

### DIFF
--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.6.2"
 nb = "0.1.2"
-fpa = "0.1.0"
+fixed = "1.0.0"
 rand_core = "0.5.1"
 cfg-if = "0.1.10"
 

--- a/nrf-hal-common/src/temp.rs
+++ b/nrf-hal-common/src/temp.rs
@@ -1,7 +1,7 @@
 //! Temperature sensor interface.
 
 use crate::pac::TEMP;
-use fpa::I30F2;
+use fixed::types::I30F2;
 use void::Void;
 
 /// Integrated temperature sensor.


### PR DESCRIPTION
This PR moves the fixed point library to one that is stable, maintained and has better functionality.

This is a breaking change, but IMO a minor one.

The only blocker I can think of is that since the 1.0 release of the fixed crate, it requires rustc 1.44 or higher. I don't see a minimum version mentioned here in the HAL though.