### PR TITLE
Add QDEC module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/ppi-demo",
   "examples/gpiote-demo",
   "examples/wdt-demo",
+  "examples/qdec-demo",
 ]
 
 [profile.dev]

--- a/examples/qdec-demo/Cargo.toml
+++ b/examples/qdec-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "qdec-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/qdec-demo/Embed.toml
+++ b/examples/qdec-demo/Embed.toml
@@ -1,0 +1,46 @@
+[probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/qdec-demo/Embed.toml
+++ b/examples/qdec-demo/Embed.toml
@@ -1,4 +1,4 @@
-[probe]
+[default.probe]
 # The index of the probe in the connected probe list.
 # probe_index = 0
 # The protocol to be used for communicating with the target.
@@ -6,7 +6,7 @@ protocol = "Swd"
 # The speed in kHz of the data link to the target.
 # speed = 1337
 
-[flashing]
+[default.flashing]
 # Whether or not the target should be flashed.
 enabled = true
 # Whether or not the target should be halted after flashing.
@@ -17,7 +17,7 @@ restore_unwritten_bytes = false
 # The path where an SVG of the assembled flash layout should be written to.
 # flash_layout_output_path = "out.svg"
 
-[general]
+[default.general]
 # The chip name of the chip to be debugged.
 chip = "nRF52840"
 # A list of chip descriptions to be loaded during runtime.
@@ -25,7 +25,7 @@ chip_descriptions = []
 # The default log level to be used.
 log_level = "Warn"
 
-[rtt]
+[default.rtt]
 # Whether or not an RTTUI should be opened after flashing.
 # This is exclusive and cannot be used with GDB at the moment.
 enabled = true
@@ -38,7 +38,7 @@ timeout = 3000
 # Whether timestamps in the RTTUI are enabled
 show_timestamps = true
 
-[gdb]
+[default.gdb]
 # Whether or not a GDB server should be opened after flashing.
 # This is exclusive and cannot be used with RTT at the moment.
 enabled = false

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -1,0 +1,56 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::InputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::qdec::*,
+    nrf52840_hal as hal,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[rtic::app(device = crate::hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        qdec: Qdec,
+        #[init(0)]
+        value: i16,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        rtt_init_print!();
+
+        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let pin_a = p0.p0_31.into_pullup_input().degrade();
+        let pin_b = p0.p0_30.into_pullup_input().degrade();
+
+        let qdec = Qdec::new(ctx.device.QDEC, pin_a, pin_b, None, SamplePeriod::_128us);
+        qdec.debounce();
+        qdec.enable_interrupt(NumSamples::_1smpl);
+        qdec.enable();
+
+        init::LateResources { qdec }
+    }
+
+    #[task(binds = QDEC, resources = [qdec, value])]
+    fn on_qdec(ctx: on_qdec::Context) {
+        ctx.resources.qdec.reset_events();
+        *ctx.resources.value += ctx.resources.qdec.read();
+        rprintln!("Value: {}", ctx.resources.value);
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -29,9 +29,9 @@ const APP: () = {
         let pin_b = p0.p0_30.into_pullup_input().degrade();
 
         let qdec = Qdec::new(ctx.device.QDEC, pin_a, pin_b, None, SamplePeriod::_128us);
-        qdec.debounce(true);
-        qdec.enable_interrupt(NumSamples::_1smpl);
-        qdec.enable();
+        qdec.debounce(true)
+            .enable_interrupt(NumSamples::_1smpl)
+            .enable();
 
         init::LateResources { qdec }
     }

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::InputPin;
 use {
     core::{
         panic::PanicInfo,

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -30,7 +30,7 @@ const APP: () = {
         let pin_b = p0.p0_30.into_pullup_input().degrade();
 
         let qdec = Qdec::new(ctx.device.QDEC, pin_a, pin_b, None, SamplePeriod::_128us);
-        qdec.debounce();
+        qdec.debounce(true);
         qdec.enable_interrupt(NumSamples::_1smpl);
         qdec.enable();
 

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -37,6 +37,8 @@ pub mod gpio;
 pub mod gpiote;
 #[cfg(not(feature = "9160"))]
 pub mod ppi;
+#[cfg(not(any(feature = "51", feature = "9160")))]
+pub mod qdec;
 #[cfg(not(feature = "9160"))]
 pub mod rng;
 pub mod rtc;

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -47,7 +47,7 @@ impl Qdec {
         if let Some(p) = &pin_led {
             qdec.psel.led.write(|w| {
                 #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(match pin_a.port() {
+                w.port().bit(match p.port() {
                     Port::Port0 => false,
                     Port::Port1 => true,
                 });

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -1,0 +1,197 @@
+//! HAL interface for the QDEC peripheral.
+//!
+//! The Quadrature decoder (QDEC) provides buffered decoding of quadrature-encoded sensor signals.
+//! It is suitable for mechanical and optical sensors.
+
+use {
+    crate::gpio::{Input, Pin, Port, PullUp},
+    crate::pac::QDEC,
+};
+
+/// A safe wrapper around the GPIOTE peripheral with associated pins
+pub struct Qdec {
+    qdec: QDEC,
+    pin_a: Pin<Input<PullUp>>,
+    pin_b: Pin<Input<PullUp>>,
+    pin_led: Option<Pin<Input<PullUp>>>,
+}
+
+impl Qdec {
+    /// Takes ownership of the `QDEC` peripheral and associated pins, returning a safe wrapper
+    pub fn new(
+        qdec: QDEC,
+        pin_a: Pin<Input<PullUp>>,
+        pin_b: Pin<Input<PullUp>>,
+        pin_led: Option<Pin<Input<PullUp>>>,
+        sample_period: SamplePeriod,
+    ) -> Self {
+        qdec.psel.a.write(|w| {
+            #[cfg(any(feature = "52833", feature = "52840"))]
+            w.port().bit(match pin_a.port() {
+                Port::Port0 => false,
+                Port::Port1 => true,
+            });
+            unsafe { w.pin().bits(pin_a.pin()) };
+            w.connect().connected()
+        });
+        qdec.psel.b.write(|w| {
+            #[cfg(any(feature = "52833", feature = "52840"))]
+            w.port().bit(match pin_a.port() {
+                Port::Port0 => false,
+                Port::Port1 => true,
+            });
+            unsafe { w.pin().bits(pin_b.pin()) };
+            w.connect().connected()
+        });
+
+        if let Some(p) = &pin_led {
+            qdec.psel.led.write(|w| {
+                #[cfg(any(feature = "52833", feature = "52840"))]
+                w.port().bit(match pin_a.port() {
+                    Port::Port0 => false,
+                    Port::Port1 => true,
+                });
+                unsafe { w.pin().bits(p.pin()) };
+                w.connect().connected()
+            });
+        }
+
+        match sample_period {
+            SamplePeriod::_128us => qdec.sampleper.write(|w| w.sampleper()._128us()),
+            SamplePeriod::_256us => qdec.sampleper.write(|w| w.sampleper()._256us()),
+            SamplePeriod::_512us => qdec.sampleper.write(|w| w.sampleper()._512us()),
+            SamplePeriod::_1024us => qdec.sampleper.write(|w| w.sampleper()._1024us()),
+            SamplePeriod::_2048us => qdec.sampleper.write(|w| w.sampleper()._2048us()),
+            SamplePeriod::_4096us => qdec.sampleper.write(|w| w.sampleper()._4096us()),
+            SamplePeriod::_8192us => qdec.sampleper.write(|w| w.sampleper()._8192us()),
+            SamplePeriod::_16384us => qdec.sampleper.write(|w| w.sampleper()._16384us()),
+            SamplePeriod::_32ms => qdec.sampleper.write(|w| w.sampleper()._32ms()),
+            SamplePeriod::_65ms => qdec.sampleper.write(|w| w.sampleper()._65ms()),
+            SamplePeriod::_131ms => qdec.sampleper.write(|w| w.sampleper()._131ms()),
+        }
+
+        Self {
+            qdec,
+            pin_a,
+            pin_b,
+            pin_led,
+        }
+    }
+
+    /// Enables input debounce filters
+    #[inline(always)]
+    pub fn debounce(&self) {
+        self.qdec.dbfen.write(|w| w.dbfen().enabled());
+    }
+
+    /// LED output pin polarity
+    #[inline(always)]
+    pub fn led_polarity(&self, polarity: LedPolarity) {
+        self.qdec.ledpol.write(|w| match polarity {
+            LedPolarity::ActiveHigh => w.ledpol().active_high(),
+            LedPolarity::ActiveLow => w.ledpol().active_low(),
+        });
+    }
+
+    /// Time period the LED is switched ON prior to sampling (0..511 us)
+    #[inline(always)]
+    pub fn led_pre(&self, usecs: u16) {
+        self.qdec
+            .ledpre
+            .write(|w| unsafe { w.ledpre().bits(usecs.min(511)) });
+    }
+
+    /// Marks the interrupt trigger event as handled
+    #[inline(always)]
+    pub fn reset_events(&self) {
+        self.qdec.events_reportrdy.write(|w| w);
+    }
+
+    /// Triggers the QDEC interrupt on the specified number of non-zero samples
+    #[inline(always)]
+    pub fn enable_interrupt(&self, num_samples: NumSamples) {
+        self.qdec.reportper.write(|w| match num_samples {
+            NumSamples::_10smpl => w.reportper()._10smpl(),
+            NumSamples::_40smpl => w.reportper()._40smpl(),
+            NumSamples::_80smpl => w.reportper()._80smpl(),
+            NumSamples::_120smpl => w.reportper()._120smpl(),
+            NumSamples::_160smpl => w.reportper()._160smpl(),
+            NumSamples::_200smpl => w.reportper()._200smpl(),
+            NumSamples::_240smpl => w.reportper()._240smpl(),
+            NumSamples::_280smpl => w.reportper()._280smpl(),
+            NumSamples::_1smpl => w.reportper()._1smpl(),
+        });
+        self.qdec.intenset.write(|w| w.reportrdy().set_bit());
+    }
+
+    /// Disables the QDEC interrupt triggering
+    #[inline(always)]
+    pub fn disable_interrupt(&self) {
+        self.qdec.intenclr.write(|w| w.reportrdy().set_bit());
+    }
+
+    /// Enables the quadrature decoder
+    #[inline(always)]
+    pub fn enable(&self) {
+        self.qdec.enable.write(|w| w.enable().set_bit());
+        self.qdec.tasks_start.write(|w| unsafe { w.bits(1) });
+    }
+
+    /// Disables the quadrature decoder
+    #[inline(always)]
+    pub fn disable(&self) {
+        self.qdec.tasks_stop.write(|w| unsafe { w.bits(1) });
+        while self.qdec.events_stopped.read().bits() == 0 {}
+        self.qdec.enable.write(|w| w.enable().clear_bit());
+    }
+
+    /// Returns the accumulated change since last read
+    #[inline(always)]
+    pub fn read(&self) -> i16 {
+        self.qdec.tasks_readclracc.write(|w| unsafe { w.bits(1) });
+        self.qdec.accread.read().bits() as i16
+    }
+
+    /// Consumes `self` and returns back the raw `QDEC` peripheral.
+    pub fn free(
+        self,
+    ) -> (
+        QDEC,
+        Pin<Input<PullUp>>,
+        Pin<Input<PullUp>>,
+        Option<Pin<Input<PullUp>>>,
+    ) {
+        (self.qdec, self.pin_a, self.pin_b, self.pin_led)
+    }
+}
+
+pub enum SamplePeriod {
+    _128us,
+    _256us,
+    _512us,
+    _1024us,
+    _2048us,
+    _4096us,
+    _8192us,
+    _16384us,
+    _32ms,
+    _65ms,
+    _131ms,
+}
+
+pub enum NumSamples {
+    _10smpl,
+    _40smpl,
+    _80smpl,
+    _120smpl,
+    _160smpl,
+    _200smpl,
+    _240smpl,
+    _280smpl,
+    _1smpl,
+}
+
+pub enum LedPolarity {
+    ActiveHigh,
+    ActiveLow,
+}

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -8,7 +8,7 @@ use {
     crate::pac::QDEC,
 };
 
-/// A safe wrapper around the GPIOTE peripheral with associated pins
+/// A safe wrapper around the `QDEC` peripheral with associated pins.
 pub struct Qdec {
     qdec: QDEC,
     pin_a: Pin<Input<PullUp>>,
@@ -17,7 +17,7 @@ pub struct Qdec {
 }
 
 impl Qdec {
-    /// Takes ownership of the `QDEC` peripheral and associated pins, returning a safe wrapper
+    /// Takes ownership of the `QDEC` peripheral and associated pins, returning a safe wrapper.
     pub fn new(
         qdec: QDEC,
         pin_a: Pin<Input<PullUp>>,
@@ -78,13 +78,16 @@ impl Qdec {
         }
     }
 
-    /// Enables input debounce filters
+    /// Enables/disables input debounce filters.
     #[inline(always)]
-    pub fn debounce(&self) {
-        self.qdec.dbfen.write(|w| w.dbfen().enabled());
+    pub fn debounce(&self, enable: bool) {
+        match enable {
+            true => self.qdec.dbfen.write(|w| w.dbfen().enabled()),
+            false => self.qdec.dbfen.write(|w| w.dbfen().disabled()),
+        }
     }
 
-    /// LED output pin polarity
+    /// LED output pin polarity.
     #[inline(always)]
     pub fn led_polarity(&self, polarity: LedPolarity) {
         self.qdec.ledpol.write(|w| match polarity {
@@ -93,7 +96,7 @@ impl Qdec {
         });
     }
 
-    /// Time period the LED is switched ON prior to sampling (0..511 us)
+    /// Time period the LED is switched ON prior to sampling (0..511 us).
     #[inline(always)]
     pub fn led_pre(&self, usecs: u16) {
         self.qdec
@@ -101,13 +104,13 @@ impl Qdec {
             .write(|w| unsafe { w.ledpre().bits(usecs.min(511)) });
     }
 
-    /// Marks the interrupt trigger event as handled
+    /// Marks the interrupt trigger event as handled.
     #[inline(always)]
     pub fn reset_events(&self) {
         self.qdec.events_reportrdy.write(|w| w);
     }
 
-    /// Triggers the QDEC interrupt on the specified number of non-zero samples
+    /// Triggers the QDEC interrupt on the specified number of non-zero samples.
     #[inline(always)]
     pub fn enable_interrupt(&self, num_samples: NumSamples) {
         self.qdec.reportper.write(|w| match num_samples {
@@ -124,20 +127,20 @@ impl Qdec {
         self.qdec.intenset.write(|w| w.reportrdy().set_bit());
     }
 
-    /// Disables the QDEC interrupt triggering
+    /// Disables the QDEC interrupt triggering.
     #[inline(always)]
     pub fn disable_interrupt(&self) {
         self.qdec.intenclr.write(|w| w.reportrdy().set_bit());
     }
 
-    /// Enables the quadrature decoder
+    /// Enables the quadrature decoder.
     #[inline(always)]
     pub fn enable(&self) {
         self.qdec.enable.write(|w| w.enable().set_bit());
         self.qdec.tasks_start.write(|w| unsafe { w.bits(1) });
     }
 
-    /// Disables the quadrature decoder
+    /// Disables the quadrature decoder.
     #[inline(always)]
     pub fn disable(&self) {
         self.qdec.tasks_stop.write(|w| unsafe { w.bits(1) });
@@ -145,7 +148,7 @@ impl Qdec {
         self.qdec.enable.write(|w| w.enable().clear_bit());
     }
 
-    /// Returns the accumulated change since last read
+    /// Returns the accumulated change since last read (-).
     #[inline(always)]
     pub fn read(&self) -> i16 {
         self.qdec.tasks_readclracc.write(|w| unsafe { w.bits(1) });
@@ -153,6 +156,7 @@ impl Qdec {
     }
 
     /// Consumes `self` and returns back the raw `QDEC` peripheral.
+    #[inline]
     pub fn free(
         self,
     ) -> (

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -3,8 +3,10 @@
 //! The Quadrature decoder (QDEC) provides buffered decoding of quadrature-encoded sensor signals.
 //! It is suitable for mechanical and optical sensors.
 
+#[cfg(any(feature = "52833", feature = "52840"))]
+use crate::gpio::Port;
 use {
-    crate::gpio::{Input, Pin, Port, PullUp},
+    crate::gpio::{Input, Pin, PullUp},
     crate::pac::QDEC,
 };
 

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -148,7 +148,7 @@ impl Qdec {
         self.qdec.enable.write(|w| w.enable().clear_bit());
     }
 
-    /// Returns the accumulated change since last read (-).
+    /// Returns the accumulated change since last read (-1024..1023).
     #[inline(always)]
     pub fn read(&self) -> i16 {
         self.qdec.tasks_readclracc.write(|w| unsafe { w.bits(1) });

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -176,6 +176,7 @@ impl Qdec {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SamplePeriod {
     _128us,
     _256us,
@@ -190,6 +191,7 @@ pub enum SamplePeriod {
     _131ms,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum NumSamples {
     _10smpl,
     _40smpl,
@@ -202,6 +204,7 @@ pub enum NumSamples {
     _1smpl,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum LedPolarity {
     ActiveHigh,
     ActiveLow,


### PR DESCRIPTION
Added a HAL module for the quadrature decoder peripheral.
Tested on NRF52840-DK with a Bourns PEC11R-4215F-S0024 rotary encoder

Demo of usage with rotary encoder triggering interrupt (nRF52840):
https://github.com/kalkyl/nrf-hal/blob/qdec/examples/qdec-demo/src/main.rs
