### PR TITLE
Add COMP module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/ppi-demo",
   "examples/gpiote-demo",
   "examples/wdt-demo",
+  "examples/comp-demo",
 ]
 
 [profile.dev]

--- a/examples/comp-demo/Cargo.toml
+++ b/examples/comp-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "comp-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/comp-demo/Embed.toml
+++ b/examples/comp-demo/Embed.toml
@@ -1,0 +1,46 @@
+[probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/comp-demo/Embed.toml
+++ b/examples/comp-demo/Embed.toml
@@ -1,4 +1,4 @@
-[probe]
+[default.probe]
 # The index of the probe in the connected probe list.
 # probe_index = 0
 # The protocol to be used for communicating with the target.
@@ -6,7 +6,7 @@ protocol = "Swd"
 # The speed in kHz of the data link to the target.
 # speed = 1337
 
-[flashing]
+[default.flashing]
 # Whether or not the target should be flashed.
 enabled = true
 # Whether or not the target should be halted after flashing.
@@ -17,7 +17,7 @@ restore_unwritten_bytes = false
 # The path where an SVG of the assembled flash layout should be written to.
 # flash_layout_output_path = "out.svg"
 
-[general]
+[default.general]
 # The chip name of the chip to be debugged.
 chip = "nRF52840"
 # A list of chip descriptions to be loaded during runtime.
@@ -25,7 +25,7 @@ chip_descriptions = []
 # The default log level to be used.
 log_level = "Warn"
 
-[rtt]
+[default.rtt]
 # Whether or not an RTTUI should be opened after flashing.
 # This is exclusive and cannot be used with GDB at the moment.
 enabled = true
@@ -38,7 +38,7 @@ timeout = 3000
 # Whether timestamps in the RTTUI are enabled
 show_timestamps = true
 
-[gdb]
+[default.gdb]
 # Whether or not a GDB server should be opened after flashing.
 # This is exclusive and cannot be used with RTT at the moment.
 enabled = false

--- a/examples/comp-demo/src/main.rs
+++ b/examples/comp-demo/src/main.rs
@@ -1,0 +1,68 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::OutputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::{
+        comp::*,
+        gpio::{Level, Output, Pin, PushPull},
+    },
+    nrf52840_hal as hal,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[rtic::app(device = crate::hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        comp: Comp,
+        led1: Pin<Output<PushPull>>,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        rtt_init_print!();
+
+        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
+        let in_pin = p0.p0_30.into_floating_input();
+        let ref_pin = p0.p0_31.into_floating_input();
+
+        let comp = Comp::new(ctx.device.COMP, &in_pin);
+        comp.differential(&ref_pin)
+            .hysteresis(true)
+            .enable_interrupt(Transition::Cross)
+            .enable();
+
+        init::LateResources { comp, led1 }
+    }
+
+    #[task(binds = COMP_LPCOMP, resources = [comp, led1])]
+    fn on_comp(ctx: on_comp::Context) {
+        ctx.resources.comp.reset_event(Transition::Cross);
+        match ctx.resources.comp.read() {
+            CompResult::Above => {
+                rprintln!("Vin > Vref");
+                ctx.resources.led1.set_low().ok();
+            }
+            CompResult::Below => {
+                rprintln!("Vin < Vref");
+                ctx.resources.led1.set_high().ok();
+            }
+        }
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -258,21 +258,15 @@ pub trait CompRefPin {
     fn aref(&self) -> EXTREFSEL_A;
 }
 
-macro_rules! comp_input_pins {
-    ($($pin:path => $ain:expr,)+) => {
+macro_rules! analog_pins {
+    ($($pin:path => ($ain:expr, $aref:expr),)+) => {
         $(
             impl CompInputPin for $pin {
                 fn ain(&self) -> PSEL_A {
                     $ain
                 }
             }
-        )*
-    };
-}
 
-macro_rules! comp_ref_pins {
-    ($($pin:path => $aref:expr,)+) => {
-        $(
             impl CompRefPin for $pin {
                 fn aref(&self) -> EXTREFSEL_A {
                     $aref
@@ -282,36 +276,25 @@ macro_rules! comp_ref_pins {
     };
 }
 
-comp_input_pins! {
-    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT0,
-    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT1,
-    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT2,
-    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT3,
-    P0_28<Input<Floating>> => PSEL_A::ANALOGINPUT4,
-    P0_29<Input<Floating>> => PSEL_A::ANALOGINPUT5,
-    P0_30<Input<Floating>> => PSEL_A::ANALOGINPUT6,
-    P0_31<Input<Floating>> => PSEL_A::ANALOGINPUT7,
-}
-
 #[cfg(not(feature = "52810"))]
-comp_ref_pins! {
-    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
-    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
-    P0_04<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE2,
-    P0_05<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE3,
-    P0_28<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE4,
-    P0_29<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE5,
-    P0_30<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE6,
-    P0_31<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE7,
+analog_pins! {
+    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
+    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
+    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
+    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
+    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
+    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
+    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
+    P0_31<Input<Floating>> => (PSEL_A::ANALOGINPUT7, EXTREFSEL_A::ANALOGREFERENCE7),
 }
 
 #[cfg(feature = "52810")]
-comp_ref_pins! {
-    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
-    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
-    P0_04<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE2,
-    P0_05<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE3,
-    P0_28<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE4,
-    P0_29<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE5,
-    P0_30<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE6,
+analog_pins! {
+    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
+    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
+    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
+    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
+    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
+    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
+    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
 }

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -221,28 +221,33 @@ impl Comp {
     }
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum OperationMode {
     Differential,
     SingleEnded,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum PowerMode {
     LowPower,
     Normal,
     HighSpeed,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum CompResult {
     Above,
     Below,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum Transition {
     Up,
     Down,
     Cross,
 }
 
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum VRef {
     Int1V2,
     Int1V8,

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -169,16 +169,19 @@ impl Comp {
     }
 
     /// Returns reference to `Up` transition event endpoint for PPI.
+    #[inline(always)]
     pub fn event_up(&self) -> &Reg<u32, _EVENTS_UP> {
         &self.comp.events_up
     }
 
     /// Returns reference to `Down` transition event endpoint for PPI.
+    #[inline(always)]
     pub fn event_down(&self) -> &Reg<u32, _EVENTS_DOWN> {
         &self.comp.events_down
     }
 
     /// Returns reference to `Cross` transition event endpoint for PPI.
+    #[inline(always)]
     pub fn event_cross(&self) -> &Reg<u32, _EVENTS_CROSS> {
         &self.comp.events_cross
     }

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -20,7 +20,7 @@ pub struct Comp {
 
 impl Comp {
     /// Takes ownership of the `COMP` peripheral, returning a safe wrapper.
-    pub fn new<P: AnalogPin>(comp: COMP, input_pin: &P) -> Self {
+    pub fn new<P: CompInputPin>(comp: COMP, input_pin: &P) -> Self {
         comp.psel.write(|w| w.psel().variant(input_pin.ain()));
         comp.mode.write(|w| w.sp().normal());
         comp.mode.write(|w| w.main().se());
@@ -54,7 +54,7 @@ impl Comp {
 
     /// Sets analog reference pin.
     #[inline(always)]
-    pub fn aref_pin<P: AnalogPin>(&self, ref_pin: &P) -> &Self {
+    pub fn aref_pin<P: CompRefPin>(&self, ref_pin: &P) -> &Self {
         self.comp
             .extrefsel
             .write(|w| w.extrefsel().variant(ref_pin.aref()));
@@ -63,7 +63,7 @@ impl Comp {
 
     /// Sets comparator mode to differential with external Vref pin.
     #[inline(always)]
-    pub fn differential<P: AnalogPin>(&self, ref_pin: &P) -> &Self {
+    pub fn differential<P: CompRefPin>(&self, ref_pin: &P) -> &Self {
         self.comp.mode.write(|w| w.main().diff());
         self.aref_pin(ref_pin);
         self
@@ -241,18 +241,30 @@ pub enum VRef {
 }
 
 /// Trait to represent analog input pins.
-pub trait AnalogPin {
+pub trait CompInputPin {
     fn ain(&self) -> PSEL_A;
+}
+/// Trait to represent analog ref pins.
+pub trait CompRefPin {
     fn aref(&self) -> EXTREFSEL_A;
 }
 
-macro_rules! analog_pins {
-    ($($pin:path => ($ain:expr, $aref:expr),)+) => {
+macro_rules! comp_input_pins {
+    ($($pin:path => $ain:expr,)+) => {
         $(
-            impl AnalogPin for $pin {
+            impl CompInputPin for $pin {
                 fn ain(&self) -> PSEL_A {
                     $ain
                 }
+            }
+        )*
+    };
+}
+
+macro_rules! comp_ref_pins {
+    ($($pin:path => $aref:expr,)+) => {
+        $(
+            impl CompRefPin for $pin {
                 fn aref(&self) -> EXTREFSEL_A {
                     $aref
                 }
@@ -261,25 +273,36 @@ macro_rules! analog_pins {
     };
 }
 
+comp_input_pins! {
+    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT0,
+    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT1,
+    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT2,
+    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT3,
+    P0_28<Input<Floating>> => PSEL_A::ANALOGINPUT4,
+    P0_29<Input<Floating>> => PSEL_A::ANALOGINPUT5,
+    P0_30<Input<Floating>> => PSEL_A::ANALOGINPUT6,
+    P0_31<Input<Floating>> => PSEL_A::ANALOGINPUT7,
+}
+
 #[cfg(not(feature = "52810"))]
-analog_pins! {
-    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
-    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
-    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
-    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
-    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
-    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
-    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
-    P0_31<Input<Floating>> => (PSEL_A::ANALOGINPUT7, EXTREFSEL_A::ANALOGREFERENCE7),
+comp_ref_pins! {
+    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
+    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
+    P0_04<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE2,
+    P0_05<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE3,
+    P0_28<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE4,
+    P0_29<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE5,
+    P0_30<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE6,
+    P0_31<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE7,
 }
 
 #[cfg(feature = "52810")]
-analog_pins! {
-    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
-    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
-    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
-    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
-    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
-    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
-    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
+comp_ref_pins! {
+    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
+    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
+    P0_04<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE2,
+    P0_05<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE3,
+    P0_28<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE4,
+    P0_29<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE5,
+    P0_30<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE6,
 }

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -258,15 +258,21 @@ pub trait CompRefPin {
     fn aref(&self) -> EXTREFSEL_A;
 }
 
-macro_rules! analog_pins {
-    ($($pin:path => ($ain:expr, $aref:expr),)+) => {
+macro_rules! comp_input_pins {
+    ($($pin:path => $ain:expr,)+) => {
         $(
             impl CompInputPin for $pin {
                 fn ain(&self) -> PSEL_A {
                     $ain
                 }
             }
+        )*
+    };
+}
 
+macro_rules! comp_ref_pins {
+    ($($pin:path => $aref:expr,)+) => {
+        $(
             impl CompRefPin for $pin {
                 fn aref(&self) -> EXTREFSEL_A {
                     $aref
@@ -276,25 +282,36 @@ macro_rules! analog_pins {
     };
 }
 
+comp_ref_pins! {
+    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
+    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
+    P0_04<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE2,
+    P0_05<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE3,
+    P0_28<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE4,
+    P0_29<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE5,
+    P0_30<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE6,
+    P0_31<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE7,
+}
+
 #[cfg(not(feature = "52810"))]
-analog_pins! {
-    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
-    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
-    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
-    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
-    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
-    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
-    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
-    P0_31<Input<Floating>> => (PSEL_A::ANALOGINPUT7, EXTREFSEL_A::ANALOGREFERENCE7),
+comp_input_pins! {
+    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT0,
+    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT1,
+    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT2,
+    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT3,
+    P0_28<Input<Floating>> => PSEL_A::ANALOGINPUT4,
+    P0_29<Input<Floating>> => PSEL_A::ANALOGINPUT5,
+    P0_30<Input<Floating>> => PSEL_A::ANALOGINPUT6,
+    P0_31<Input<Floating>> => PSEL_A::ANALOGINPUT7,
 }
 
 #[cfg(feature = "52810")]
-analog_pins! {
-    P0_02<Input<Floating>> => (PSEL_A::ANALOGINPUT0, EXTREFSEL_A::ANALOGREFERENCE0),
-    P0_03<Input<Floating>> => (PSEL_A::ANALOGINPUT1, EXTREFSEL_A::ANALOGREFERENCE1),
-    P0_04<Input<Floating>> => (PSEL_A::ANALOGINPUT2, EXTREFSEL_A::ANALOGREFERENCE2),
-    P0_05<Input<Floating>> => (PSEL_A::ANALOGINPUT3, EXTREFSEL_A::ANALOGREFERENCE3),
-    P0_28<Input<Floating>> => (PSEL_A::ANALOGINPUT4, EXTREFSEL_A::ANALOGREFERENCE4),
-    P0_29<Input<Floating>> => (PSEL_A::ANALOGINPUT5, EXTREFSEL_A::ANALOGREFERENCE5),
-    P0_30<Input<Floating>> => (PSEL_A::ANALOGINPUT6, EXTREFSEL_A::ANALOGREFERENCE6),
+comp_input_pins! {
+    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT0,
+    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT1,
+    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT2,
+    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT3,
+    P0_28<Input<Floating>> => PSEL_A::ANALOGINPUT4,
+    P0_29<Input<Floating>> => PSEL_A::ANALOGINPUT5,
+    P0_30<Input<Floating>> => PSEL_A::ANALOGINPUT6,
 }

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -1,0 +1,277 @@
+//! HAL interface for the COMP peripheral.
+//!
+//! The comparator (COMP) compares an input voltage (Vin) against a second input voltage (Vref).
+//! Vin can be derived from an analog input pin (AIN0-AIN7).
+//! Vref can be derived from multiple sources depending on the operation mode of the comparator.
+
+use {
+    crate::gpio::{Floating, Input},
+    crate::pac::comp::{_EVENTS_CROSS, _EVENTS_DOWN, _EVENTS_UP},
+    crate::pac::{generic::Reg, COMP},
+};
+
+/// A safe wrapper around the `COMP` peripheral.
+pub struct Comp {
+    comp: COMP,
+}
+
+impl Comp {
+    /// Takes ownership of the `COMP` peripheral, returning a safe wrapper.
+    pub fn new<P: AnalogPin>(comp: COMP, input_pin: &P) -> Self {
+        comp.psel.write(|w| match input_pin.ain() {
+            0 => w.psel().analog_input0(),
+            1 => w.psel().analog_input1(),
+            2 => w.psel().analog_input2(),
+            3 => w.psel().analog_input3(),
+            4 => w.psel().analog_input4(),
+            5 => w.psel().analog_input5(),
+            6 => w.psel().analog_input6(),
+            7 => w.psel().analog_input7(),
+            _ => unreachable!(),
+        });
+        comp.mode.write(|w| w.sp().normal());
+        comp.mode.write(|w| w.main().se());
+        comp.refsel.write(|w| w.refsel().int1v2());
+        Self { comp }
+    }
+
+    /// Sets the speed and power mode of the comparator.
+    #[inline(always)]
+    pub fn power_mode(&self, mode: PowerMode) -> &Self {
+        match mode {
+            PowerMode::LowPower => self.comp.mode.write(|w| w.sp().low()),
+            PowerMode::Normal => self.comp.mode.write(|w| w.sp().normal()),
+            PowerMode::HighSpeed => self.comp.mode.write(|w| w.sp().high()),
+        }
+        self
+    }
+
+    /// Sets Vref of the comparator in single ended mode.
+    #[inline(always)]
+    pub fn vref(&self, vref: VRef) -> &Self {
+        self.comp.refsel.write(|w| match vref {
+            VRef::Int1V2 => w.refsel().int1v2(),
+            VRef::Int1V8 => w.refsel().int1v8(),
+            VRef::Int2V4 => w.refsel().int2v4(),
+            VRef::Vdd => w.refsel().vdd(),
+            VRef::ARef => w.refsel().aref(),
+        });
+        self
+    }
+
+    /// Sets analog reference pin.
+    #[inline(always)]
+    pub fn aref_pin<P: AnalogPin>(&self, ref_pin: &P) -> &Self {
+        self.comp.extrefsel.write(|w| match ref_pin.ain() {
+            0 => w.extrefsel().analog_reference0(),
+            1 => w.extrefsel().analog_reference1(),
+            2 => w.extrefsel().analog_reference2(),
+            3 => w.extrefsel().analog_reference3(),
+            4 => w.extrefsel().analog_reference4(),
+            5 => w.extrefsel().analog_reference5(),
+            6 => w.extrefsel().analog_reference6(),
+            7 => w.extrefsel().analog_reference7(),
+            _ => unreachable!(),
+        });
+        self
+    }
+
+    /// Sets comparator mode to differential with external Vref pin.
+    #[inline(always)]
+    pub fn differential<P: AnalogPin>(&self, ref_pin: &P) -> &Self {
+        self.comp.mode.write(|w| w.main().diff());
+        self.aref_pin(ref_pin);
+        self
+    }
+
+    /// Rising hysteresis threshold in single ended mode `Vup = (value+1)/64*Vref`.
+    #[inline(always)]
+    pub fn hysteresis_threshold_up(&self, value: u8) -> &Self {
+        self.comp
+            .th
+            .write(|w| unsafe { w.thup().bits(value.min(63)) });
+        self
+    }
+
+    /// Falling hysteresis threshold in single ended mode `Vdown = (value+1)/64*Vref`.
+    #[inline(always)]
+    pub fn hysteresis_threshold_down(&self, value: u8) -> &Self {
+        self.comp
+            .th
+            .write(|w| unsafe { w.thdown().bits(value.min(63)) });
+        self
+    }
+
+    /// Enables/disables differential comparator hysteresis (50mV).
+    #[inline(always)]
+    pub fn hysteresis(&self, enabled: bool) -> &Self {
+        self.comp.hyst.write(|w| match enabled {
+            true => w.hyst().hyst50m_v(),
+            false => w.hyst().no_hyst(),
+        });
+        self
+    }
+
+    /// Enables `COMP_LPCOMP` interrupt triggering on the specified event.
+    #[inline(always)]
+    pub fn enable_interrupt(&self, event: Transition) -> &Self {
+        self.comp.intenset.modify(|_r, w| match event {
+            Transition::Cross => w.cross().set_bit(),
+            Transition::Down => w.down().set_bit(),
+            Transition::Up => w.up().set_bit(),
+        });
+        self
+    }
+
+    /// Disables `COMP_LPCOMP` interrupt triggering on the specified event.
+    #[inline(always)]
+    pub fn disable_interrupt(&self, event: Transition) -> &Self {
+        self.comp.intenclr.modify(|_r, w| match event {
+            Transition::Cross => w.cross().set_bit(),
+            Transition::Down => w.down().set_bit(),
+            Transition::Up => w.up().set_bit(),
+        });
+        self
+    }
+
+    /// Enables the comparator and waits until it's ready to use.
+    #[inline(always)]
+    pub fn enable(&self) {
+        self.comp.enable.write(|w| w.enable().enabled());
+        self.comp.tasks_start.write(|w| unsafe { w.bits(1) });
+        while self.comp.events_ready.read().bits() == 0 {}
+    }
+
+    /// Disables the comparator.
+    #[inline(always)]
+    pub fn disable(&self) {
+        self.comp.tasks_stop.write(|w| unsafe { w.bits(1) });
+        self.comp.enable.write(|w| w.enable().disabled());
+    }
+
+    /// Checks if the `Up` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_up(&self) -> bool {
+        self.comp.events_up.read().bits() != 0
+    }
+
+    /// Checks if the `Down` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_down(&self) -> bool {
+        self.comp.events_down.read().bits() != 0
+    }
+
+    /// Checks if the `Cross` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_cross(&self) -> bool {
+        self.comp.events_cross.read().bits() != 0
+    }
+
+    /// Returns reference to `Up` transition event endpoint for PPI.
+    pub fn event_up(&self) -> &Reg<u32, _EVENTS_UP> {
+        &self.comp.events_up
+    }
+
+    /// Returns reference to `Down` transition event endpoint for PPI.
+    pub fn event_down(&self) -> &Reg<u32, _EVENTS_DOWN> {
+        &self.comp.events_down
+    }
+
+    /// Returns reference to `Cross` transition event endpoint for PPI.
+    pub fn event_cross(&self) -> &Reg<u32, _EVENTS_CROSS> {
+        &self.comp.events_cross
+    }
+
+    /// Marks event as handled.
+    #[inline(always)]
+    pub fn reset_event(&self, event: Transition) {
+        match event {
+            Transition::Cross => self.comp.events_cross.write(|w| w),
+            Transition::Down => self.comp.events_down.write(|w| w),
+            Transition::Up => self.comp.events_up.write(|w| w),
+        }
+    }
+
+    /// Marks all events as handled.
+    #[inline(always)]
+    pub fn reset_events(&self) {
+        self.comp.events_cross.write(|w| w);
+        self.comp.events_down.write(|w| w);
+        self.comp.events_up.write(|w| w);
+    }
+
+    /// Returns the output state of the comparator.
+    #[inline(always)]
+    pub fn read(&self) -> CompResult {
+        self.comp.tasks_sample.write(|w| unsafe { w.bits(1) });
+        match self.comp.result.read().result().is_above() {
+            true => CompResult::Above,
+            false => CompResult::Below,
+        }
+    }
+
+    /// Consumes `self` and returns back the raw `COMP` peripheral.
+    #[inline(always)]
+    pub fn free(self) -> COMP {
+        self.comp
+    }
+}
+
+pub enum OperationMode {
+    Differential,
+    SingleEnded,
+}
+
+pub enum PowerMode {
+    LowPower,
+    Normal,
+    HighSpeed,
+}
+
+pub enum CompResult {
+    Above,
+    Below,
+}
+
+pub enum Transition {
+    Up,
+    Down,
+    Cross,
+}
+
+pub enum VRef {
+    Int1V2,
+    Int1V8,
+    Int2V4,
+    Vdd,
+    ARef,
+}
+
+/// Trait to represent analog input pins.
+pub trait AnalogPin {
+    /// Returns `AIN` id.
+    fn ain(&self) -> u8;
+}
+
+macro_rules! analog_pins {
+    ($($n:expr => $pin:path),*) => {
+        $(
+            impl AnalogPin for $pin {
+                fn ain(&self) -> u8 {
+                    $n
+                }
+            }
+        )*
+    };
+}
+
+analog_pins! {
+    0 => crate::gpio::p0::P0_02<Input<Floating>>,
+    1 => crate::gpio::p0::P0_03<Input<Floating>>,
+    2 => crate::gpio::p0::P0_04<Input<Floating>>,
+    3 => crate::gpio::p0::P0_05<Input<Floating>>,
+    4 => crate::gpio::p0::P0_28<Input<Floating>>,
+    5 => crate::gpio::p0::P0_29<Input<Floating>>,
+    6 => crate::gpio::p0::P0_30<Input<Floating>>,
+    7 => crate::gpio::p0::P0_31<Input<Floating>>
+}

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -26,6 +26,7 @@ impl Comp {
             4 => w.psel().analog_input4(),
             5 => w.psel().analog_input5(),
             6 => w.psel().analog_input6(),
+            #[cfg(not(feature = "52810"))]
             7 => w.psel().analog_input7(),
             _ => unreachable!(),
         });
@@ -84,7 +85,7 @@ impl Comp {
         self
     }
 
-    /// Rising hysteresis threshold in single ended mode `Vup = (value+1)/64*Vref`.
+    /// Upward hysteresis threshold in single ended mode `Vup = (value+1)/64*Vref`.
     #[inline(always)]
     pub fn hysteresis_threshold_up(&self, value: u8) -> &Self {
         self.comp
@@ -93,7 +94,7 @@ impl Comp {
         self
     }
 
-    /// Falling hysteresis threshold in single ended mode `Vdown = (value+1)/64*Vref`.
+    /// Downward hysteresis threshold in single ended mode `Vdown = (value+1)/64*Vref`.
     #[inline(always)]
     pub fn hysteresis_threshold_down(&self, value: u8) -> &Self {
         self.comp

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -47,7 +47,10 @@ impl Comp {
             VRef::Int1V8 => w.refsel().int1v8(),
             VRef::Int2V4 => w.refsel().int2v4(),
             VRef::Vdd => w.refsel().vdd(),
-            VRef::ARef => w.refsel().aref(),
+            VRef::ARef(r) => {
+                self.comp.extrefsel.write(|w| w.extrefsel().variant(r));
+                w.refsel().aref()
+            }
         });
         self
     }
@@ -231,13 +234,19 @@ pub enum Transition {
     Cross,
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 pub enum VRef {
     Int1V2,
     Int1V8,
     Int2V4,
     Vdd,
-    ARef,
+    ARef(EXTREFSEL_A),
+}
+
+impl VRef {
+    pub fn from_pin<P: CompRefPin>(pin: &P) -> Self {
+        VRef::ARef(pin.aref())
+    }
 }
 
 /// Trait to represent analog input pins.

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -28,6 +28,8 @@ pub mod adc;
 #[cfg(not(feature = "9160"))]
 pub mod ccm;
 pub mod clocks;
+#[cfg(not(any(feature = "51", feature = "9160")))]
+pub mod comp;
 #[cfg(not(feature = "51"))]
 pub mod delay;
 #[cfg(not(feature = "9160"))]


### PR DESCRIPTION
Added a HAL module for the `COMP` analog comparator peripheral.
The comparator compares an input voltage (Vin) against a second input voltage (Vref).
Vin can be derived from an analog input pin (AIN0-AIN7).
Vref can be derived from multiple sources depending on the operation mode of the comparator.
Tested on NRF52840-DK

Demo (nRF52840):
https://github.com/kalkyl/nrf-hal/blob/comp/examples/comp-demo/src/main.rs