### PR TITLE
Remove `Spi::read`

### DIFF
--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -63,11 +63,11 @@ fn main() -> ! {
 
     // This will write 8 bytes, then shift out ORC
 
-    // Note :     spi.read( &mut cs.degrade(), reference_data, &mut readbuf )
-    //            will fail because reference data is in flash, the copy to
-    //            an array will move it to RAM.
+    // Note: `spi.transfer_split_uneven(&mut cs.degrade(), reference_data, &mut readbuf)`
+    //       will fail because reference data is in flash, the copy to an array
+    //       will move it to RAM.
 
-    match spi.read(&mut cs.degrade(), &test_vec1, &mut readbuf) {
+    match spi.transfer_split_uneven(&mut cs.degrade(), &test_vec1, &mut readbuf) {
         Ok(_) => {
             for i in 0..test_vec1.len() {
                 tests_ok &= test_vec1[i] == readbuf[i];

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -220,19 +220,6 @@ where
         Ok(())
     }
 
-    /// Read from an SPI slave.
-    ///
-    /// This method is deprecated. Consider using `transfer` or `transfer_split`.
-    #[inline(always)]
-    pub fn read(
-        &mut self,
-        chip_select: &mut Pin<Output<PushPull>>,
-        tx_buffer: &[u8],
-        rx_buffer: &mut [u8],
-    ) -> Result<(), Error> {
-        self.transfer_split_uneven(chip_select, tx_buffer, rx_buffer)
-    }
-
     /// Read and write from a SPI slave, using a single buffer.
     ///
     /// This method implements a complete read transaction, which consists of


### PR DESCRIPTION
It was deprecated a while ago. Breaking change.