### PR TITLE
Add LPCOMP module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "examples/ppi-demo",
   "examples/gpiote-demo",
   "examples/wdt-demo",
+  "examples/lpcomp-demo",
 ]
 
 [profile.dev]

--- a/examples/lpcomp-demo/Cargo.toml
+++ b/examples/lpcomp-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "comp-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/lpcomp-demo/Embed.toml
+++ b/examples/lpcomp-demo/Embed.toml
@@ -1,0 +1,46 @@
+[default.probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[default.flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[default.general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[default.rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[default.gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/lpcomp-demo/src/main.rs
+++ b/examples/lpcomp-demo/src/main.rs
@@ -33,7 +33,7 @@ const APP: () = {
 
         let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
         let btn1 = p0.p0_11.into_pullup_input().degrade();
-        let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
+        let mut led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
         let in_pin = p0.p0_04.into_floating_input();
         let ref_pin = p0.p0_03.into_floating_input();
 
@@ -45,6 +45,12 @@ const APP: () = {
             .analog_detect(Transition::Up) // Power up the device on upward transition
             .enable_interrupt(Transition::Cross) // Trigger `COMP_LPCOMP` interrupt on any transition
             .enable();
+
+        // Read initial comparator state and set led on/off
+        match lpcomp.read() {
+            CompResult::Above => led1.set_low().ok(),
+            CompResult::Below => led1.set_high().ok(),
+        };
 
         let gpiote = Gpiote::new(ctx.device.GPIOTE);
         gpiote

--- a/examples/lpcomp-demo/src/main.rs
+++ b/examples/lpcomp-demo/src/main.rs
@@ -1,0 +1,113 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::OutputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::{
+        gpio::{Level, Output, Pin, PushPull},
+        gpiote::Gpiote,
+        lpcomp::*,
+        pac::POWER,
+    },
+    nrf52840_hal as hal,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[rtic::app(device = crate::hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        gpiote: Gpiote,
+        led1: Pin<Output<PushPull>>,
+        lpcomp: LpComp,
+        power: POWER,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        rtt_init_print!();
+
+        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let btn1 = p0.p0_11.into_pullup_input().degrade();
+        let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
+        let in_pin = p0.p0_04.into_floating_input();
+        let ref_pin = p0.p0_03.into_floating_input();
+
+        let lpcomp = LpComp::new(ctx.device.LPCOMP, &in_pin);
+        lpcomp
+            .vref(VRef::ARef) // Set Vref to external analog reference
+            .aref_pin(&ref_pin) // External analog reference pin
+            .hysteresis(true)
+            .analog_detect(Transition::Up) // Power up the device on upward transition
+            .enable_interrupt(Transition::Cross) // Trigger `COMP_LPCOMP` interrupt on any transition
+            .enable();
+
+        let gpiote = Gpiote::new(ctx.device.GPIOTE);
+        gpiote
+            .channel0()
+            .input_pin(&btn1)
+            .hi_to_lo()
+            .enable_interrupt();
+
+        rprintln!("Power ON");
+
+        // Check if the device was powered up by the comparator
+        if ctx.device.POWER.resetreas.read().lpcomp().is_detected() {
+            // Clear the lpcomp reset reason bit
+            ctx.device
+                .POWER
+                .resetreas
+                .modify(|_r, w| w.lpcomp().set_bit());
+            rprintln!("Powered up by the comparator!");
+        }
+
+        rprintln!("Press button 1 to shut down");
+
+        init::LateResources {
+            gpiote,
+            led1,
+            lpcomp,
+            power: ctx.device.POWER,
+        }
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        loop {
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(binds = GPIOTE, resources = [gpiote, power])]
+    fn on_gpiote(ctx: on_gpiote::Context) {
+        ctx.resources.gpiote.reset_events();
+        rprintln!("Power OFF");
+        ctx.resources
+            .power
+            .systemoff
+            .write(|w| w.systemoff().enter());
+    }
+
+    #[task(binds = COMP_LPCOMP, resources = [lpcomp, led1])]
+    fn on_comp(ctx: on_comp::Context) {
+        ctx.resources.lpcomp.reset_events();
+        match ctx.resources.lpcomp.read() {
+            CompResult::Above => ctx.resources.led1.set_low().ok(),
+            CompResult::Below => ctx.resources.led1.set_high().ok(),
+        };
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -35,6 +35,8 @@ pub mod ecb;
 pub mod gpio;
 #[cfg(not(feature = "9160"))]
 pub mod gpiote;
+#[cfg(not(any(feature = "52810", feature = "9160")))]
+pub mod lpcomp;
 #[cfg(not(feature = "9160"))]
 pub mod ppi;
 #[cfg(not(feature = "9160"))]

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -147,9 +147,9 @@ impl LpComp {
     #[inline(always)]
     pub fn reset_event(&self, event: Transition) {
         match event {
-            Transition::Cross => self.lpcomp.events_cross.write(|w| w),
-            Transition::Down => self.lpcomp.events_down.write(|w| w),
-            Transition::Up => self.lpcomp.events_up.write(|w| w),
+            Transition::Cross => self.lpcomp.events_cross.reset(),
+            Transition::Down => self.lpcomp.events_down.reset(),
+            Transition::Up => self.lpcomp.events_up.reset(),
         }
     }
 

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -1,8 +1,11 @@
 //! HAL interface for the LPCOMP peripheral.
 //!
-//! The comparator (LPCOMP) compares an input voltage (Vin) against a second input voltage (Vref).
-//! Vin can be derived from an analog input pin (AIN0-AIN7).
-//! Vref can be derived from multiple sources depending on the operation mode of the comparator.
+//! In System ON, the LPCOMP can generate separate events on rising and falling edges of a signal,
+//! or sample the current state of the pin as being above or below the selected reference.
+//! The block can be configured to use any of the analog inputs on the device.
+//! Additionally, the low power comparator can be used as an analog wakeup source from System OFF.
+//! The comparator threshold can be programmed to a range of fractions of the supply voltage
+//! or to use an external analog reference input pin.
 
 use {
     crate::gpio::{p0::*, Floating, Input},
@@ -22,8 +25,9 @@ impl LpComp {
     /// Takes ownership of the `LPCOMP` peripheral, returning a safe wrapper.
     pub fn new<P: LpCompInputPin>(lpcomp: LPCOMP, input_pin: &P) -> Self {
         lpcomp.psel.write(|w| w.psel().variant(input_pin.ain()));
-        #[cfg(not(feature = "51"))]
-        lpcomp.refsel.write(|w| w.refsel().ref4_8vdd());
+        lpcomp
+            .refsel
+            .write(|w| w.refsel().bits(VRef::_4_8Vdd.into()));
         Self { lpcomp }
     }
 

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -1,0 +1,291 @@
+//! HAL interface for the LPCOMP peripheral.
+//!
+//! The comparator (LPCOMP) compares an input voltage (Vin) against a second input voltage (Vref).
+//! Vin can be derived from an analog input pin (AIN0-AIN7).
+//! Vref can be derived from multiple sources depending on the operation mode of the comparator.
+
+use {
+    crate::gpio::{p0::*, Floating, Input},
+    crate::pac::{
+        generic::Reg,
+        lpcomp::{extrefsel::EXTREFSEL_A, psel::PSEL_A, _EVENTS_CROSS, _EVENTS_DOWN, _EVENTS_UP},
+        LPCOMP,
+    },
+};
+
+/// A safe wrapper around the `LPCOMP` peripheral.
+pub struct LpComp {
+    lpcomp: LPCOMP,
+}
+
+impl LpComp {
+    /// Takes ownership of the `LPCOMP` peripheral, returning a safe wrapper.
+    pub fn new<P: LpCompInputPin>(lpcomp: LPCOMP, input_pin: &P) -> Self {
+        lpcomp.psel.write(|w| w.psel().variant(input_pin.ain()));
+        #[cfg(not(feature = "51"))]
+        lpcomp.refsel.write(|w| w.refsel().ref4_8vdd());
+        Self { lpcomp }
+    }
+
+    /// Selects comparator Vref.
+    #[inline(always)]
+    pub fn vref(&self, vref: VRef) -> &Self {
+        self.lpcomp.refsel.write(|w| w.refsel().bits(vref.into()));
+        self
+    }
+
+    /// Sets analog reference pin.
+    #[inline(always)]
+    pub fn aref_pin<P: LpCompRefPin>(&self, ref_pin: &P) -> &Self {
+        self.lpcomp
+            .extrefsel
+            .write(|w| w.extrefsel().variant(ref_pin.aref()));
+        self
+    }
+
+    /// Enables/disables differential comparator hysteresis (50mV).
+    #[cfg(not(feature = "51"))]
+    #[inline(always)]
+    pub fn hysteresis(&self, enabled: bool) -> &Self {
+        self.lpcomp.hyst.write(|w| match enabled {
+            true => w.hyst().set_bit(),
+            false => w.hyst().clear_bit(),
+        });
+        self
+    }
+
+    /// Analog detect configuration.
+    #[cfg(not(feature = "51"))]
+    #[inline(always)]
+    pub fn analog_detect(&self, event: Transition) -> &Self {
+        self.lpcomp.anadetect.write(|w| match event {
+            Transition::Cross => w.anadetect().cross(),
+            Transition::Down => w.anadetect().down(),
+            Transition::Up => w.anadetect().up(),
+        });
+        self
+    }
+
+    /// Enables `COMP_LPCOMP` interrupt triggering on the specified event.
+    #[inline(always)]
+    pub fn enable_interrupt(&self, event: Transition) -> &Self {
+        self.lpcomp.intenset.modify(|_r, w| match event {
+            Transition::Cross => w.cross().set_bit(),
+            Transition::Down => w.down().set_bit(),
+            Transition::Up => w.up().set_bit(),
+        });
+        self
+    }
+
+    /// Disables `COMP_LPCOMP` interrupt triggering on the specified event.
+    #[inline(always)]
+    pub fn disable_interrupt(&self, event: Transition) -> &Self {
+        self.lpcomp.intenclr.modify(|_r, w| match event {
+            Transition::Cross => w.cross().set_bit(),
+            Transition::Down => w.down().set_bit(),
+            Transition::Up => w.up().set_bit(),
+        });
+        self
+    }
+
+    /// Enables the comparator and waits until it's ready to use.
+    #[inline(always)]
+    pub fn enable(&self) {
+        self.lpcomp.enable.write(|w| w.enable().enabled());
+        self.lpcomp.tasks_start.write(|w| unsafe { w.bits(1) });
+        while self.lpcomp.events_ready.read().bits() == 0 {}
+    }
+
+    /// Disables the comparator.
+    #[inline(always)]
+    pub fn disable(&self) {
+        self.lpcomp.tasks_stop.write(|w| unsafe { w.bits(1) });
+        self.lpcomp.enable.write(|w| w.enable().disabled());
+    }
+
+    /// Checks if the `Up` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_up(&self) -> bool {
+        self.lpcomp.events_up.read().bits() != 0
+    }
+
+    /// Checks if the `Down` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_down(&self) -> bool {
+        self.lpcomp.events_down.read().bits() != 0
+    }
+
+    /// Checks if the `Cross` transition event has been triggered.
+    #[inline(always)]
+    pub fn is_cross(&self) -> bool {
+        self.lpcomp.events_cross.read().bits() != 0
+    }
+
+    /// Returns reference to `Up` transition event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_up(&self) -> &Reg<u32, _EVENTS_UP> {
+        &self.lpcomp.events_up
+    }
+
+    /// Returns reference to `Down` transition event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_down(&self) -> &Reg<u32, _EVENTS_DOWN> {
+        &self.lpcomp.events_down
+    }
+
+    /// Returns reference to `Cross` transition event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_cross(&self) -> &Reg<u32, _EVENTS_CROSS> {
+        &self.lpcomp.events_cross
+    }
+
+    /// Marks event as handled.
+    #[inline(always)]
+    pub fn reset_event(&self, event: Transition) {
+        match event {
+            Transition::Cross => self.lpcomp.events_cross.write(|w| w),
+            Transition::Down => self.lpcomp.events_down.write(|w| w),
+            Transition::Up => self.lpcomp.events_up.write(|w| w),
+        }
+    }
+
+    /// Marks all events as handled.
+    #[inline(always)]
+    pub fn reset_events(&self) {
+        self.lpcomp.events_cross.write(|w| w);
+        self.lpcomp.events_down.write(|w| w);
+        self.lpcomp.events_up.write(|w| w);
+    }
+
+    /// Returns the output state of the comparator.
+    #[inline(always)]
+    pub fn read(&self) -> CompResult {
+        self.lpcomp.tasks_sample.write(|w| unsafe { w.bits(1) });
+        match self.lpcomp.result.read().result().is_above() {
+            true => CompResult::Above,
+            false => CompResult::Below,
+        }
+    }
+
+    /// Consumes `self` and returns back the raw `LPCOMP` peripheral.
+    #[inline(always)]
+    pub fn free(self) -> LPCOMP {
+        self.lpcomp
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum CompResult {
+    Above,
+    Below,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum Transition {
+    Up,
+    Down,
+    Cross,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub enum VRef {
+    _1_8Vdd = 0,
+    _2_8Vdd = 1,
+    _3_8Vdd = 2,
+    _4_8Vdd = 3,
+    _5_8Vdd = 4,
+    _6_8Vdd = 5,
+    _7_8Vdd = 6,
+    ARef = 7,
+    #[cfg(not(feature = "51"))]
+    _1_16Vdd = 8,
+    #[cfg(not(feature = "51"))]
+    _3_16Vdd = 9,
+    #[cfg(not(feature = "51"))]
+    _5_16Vdd = 10,
+    #[cfg(not(feature = "51"))]
+    _7_16Vdd = 11,
+    #[cfg(not(feature = "51"))]
+    _9_16Vdd = 12,
+    #[cfg(not(feature = "51"))]
+    _11_16Vdd = 13,
+    #[cfg(not(feature = "51"))]
+    _13_16Vdd = 14,
+    #[cfg(not(feature = "51"))]
+    _15_16Vdd = 15,
+}
+
+impl From<VRef> for u8 {
+    #[inline(always)]
+    fn from(variant: VRef) -> Self {
+        variant as _
+    }
+}
+/// Trait to represent analog input pins.
+pub trait LpCompInputPin {
+    fn ain(&self) -> PSEL_A;
+}
+/// Trait to represent analog ref pins.
+pub trait LpCompRefPin {
+    fn aref(&self) -> EXTREFSEL_A;
+}
+
+macro_rules! comp_input_pins {
+    ($($pin:path => $ain:expr,)+) => {
+        $(
+            impl LpCompInputPin for $pin {
+                fn ain(&self) -> PSEL_A {
+                    $ain
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! comp_ref_pins {
+    ($($pin:path => $aref:expr,)+) => {
+        $(
+            impl LpCompRefPin for $pin {
+                fn aref(&self) -> EXTREFSEL_A {
+                    $aref
+                }
+            }
+        )*
+    };
+}
+
+#[cfg(not(feature = "51"))]
+comp_ref_pins! {
+    P0_02<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
+    P0_03<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
+}
+
+#[cfg(not(feature = "51"))]
+comp_input_pins! {
+    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT0,
+    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT1,
+    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT2,
+    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT3,
+    P0_28<Input<Floating>> => PSEL_A::ANALOGINPUT4,
+    P0_29<Input<Floating>> => PSEL_A::ANALOGINPUT5,
+    P0_30<Input<Floating>> => PSEL_A::ANALOGINPUT6,
+    P0_31<Input<Floating>> => PSEL_A::ANALOGINPUT7,
+}
+
+#[cfg(feature = "51")]
+comp_ref_pins! {
+    P0_00<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE0,
+    P0_06<Input<Floating>> => EXTREFSEL_A::ANALOGREFERENCE1,
+}
+
+#[cfg(feature = "51")]
+comp_input_pins! {
+    P0_26<Input<Floating>> => PSEL_A::ANALOGINPUT0,
+    P0_27<Input<Floating>> => PSEL_A::ANALOGINPUT1,
+    P0_01<Input<Floating>> => PSEL_A::ANALOGINPUT2,
+    P0_02<Input<Floating>> => PSEL_A::ANALOGINPUT3,
+    P0_03<Input<Floating>> => PSEL_A::ANALOGINPUT4,
+    P0_04<Input<Floating>> => PSEL_A::ANALOGINPUT5,
+    P0_05<Input<Floating>> => PSEL_A::ANALOGINPUT6,
+    P0_06<Input<Floating>> => PSEL_A::ANALOGINPUT7,
+}

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -22,7 +22,8 @@ pub struct LpComp {
 }
 
 impl LpComp {
-    /// Takes ownership of the `LPCOMP` peripheral, returning a safe wrapper.
+    /// Takes ownership of the `LPCOMP` peripheral, returning a safe wrapper
+    /// using specified input pin and a default Vref of Vdd/2.
     pub fn new<P: LpCompInputPin>(lpcomp: LPCOMP, input_pin: &P) -> Self {
         lpcomp.psel.write(|w| w.psel().variant(input_pin.ain()));
         lpcomp

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -47,7 +47,7 @@ impl LpComp {
         self
     }
 
-    /// Enables/disables differential comparator hysteresis (50mV).
+    /// Enables/disables comparator hysteresis.
     #[cfg(not(feature = "51"))]
     #[inline(always)]
     pub fn hysteresis(&self, enabled: bool) -> &Self {
@@ -58,7 +58,7 @@ impl LpComp {
         self
     }
 
-    /// Analog detect configuration.
+    /// `Analog detect` event configuration, used for analog signal power up from OFF.
     #[cfg(not(feature = "51"))]
     #[inline(always)]
     pub fn analog_detect(&self, event: Transition) -> &Self {

--- a/nrf-hal-common/src/lpcomp.rs
+++ b/nrf-hal-common/src/lpcomp.rs
@@ -156,9 +156,9 @@ impl LpComp {
     /// Marks all events as handled.
     #[inline(always)]
     pub fn reset_events(&self) {
-        self.lpcomp.events_cross.write(|w| w);
-        self.lpcomp.events_down.write(|w| w);
-        self.lpcomp.events_up.write(|w| w);
+        self.lpcomp.events_cross.reset();
+        self.lpcomp.events_down.reset();
+        self.lpcomp.events_up.reset();
     }
 
     /// Returns the output state of the comparator.


### PR DESCRIPTION
Added a HAL module for the LPCOMP low power comparator peripheral.

In System ON, the LPCOMP can generate separate events on rising and falling edges of a signal, or sample the current state of the pin as being above or below the selected reference. The block can be configured to use any of the analog inputs on the device.

Additionally, the low power comparator can be used as an analog wakeup source from System OFF or System ON. The comparator threshold can be programmed to a range of fractions of the supply voltage or to use an external analog reference input pin.

Tested on nRF52840-DK

Demo showing "analog power up" usage and interrupt triggering/reading comparator state:
https://github.com/kalkyl/nrf-hal/blob/lpcomp/examples/lpcomp-demo/src/main.rs