### PR TITLE
Add TWIS module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
   "examples/gpiote-demo",
   "examples/wdt-demo",
   "examples/comp-demo",
+  "examples/twim-demo",
+  "examples/twis-demo",
 ]
 
 [profile.dev]

--- a/examples/twim-demo/Cargo.toml
+++ b/examples/twim-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "twim-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/twim-demo/Embed.toml
+++ b/examples/twim-demo/Embed.toml
@@ -1,0 +1,46 @@
+[default.probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[default.flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[default.general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[default.rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[default.gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/twim-demo/src/main.rs
+++ b/examples/twim-demo/src/main.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+
+use embedded_hal::digital::v2::InputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::{
+        gpio::{p0::Parts, Input, Pin, PullUp},
+        gpiote::Gpiote,
+        pac::TWIM0,
+        twim::*,
+    },
+    nrf52840_hal as hal,
+    rtic::cyccnt::U32Ext,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[rtic::app(device = crate::hal::pac, peripherals = true,  monotonic = rtic::cyccnt::CYCCNT)]
+const APP: () = {
+    struct Resources {
+        twim: Twim<TWIM0>,
+        gpiote: Gpiote,
+        btn1: Pin<Input<PullUp>>,
+        btn2: Pin<Input<PullUp>>,
+        btn3: Pin<Input<PullUp>>,
+        btn4: Pin<Input<PullUp>>,
+    }
+
+    #[init]
+    fn init(mut ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        ctx.core.DCB.enable_trace();
+        ctx.core.DWT.enable_cycle_counter();
+        rtt_init_print!();
+
+        let p0 = Parts::new(ctx.device.P0);
+        let scl = p0.p0_30.into_floating_input().degrade();
+        let sda = p0.p0_31.into_floating_input().degrade();
+        let btn1 = p0.p0_11.into_pullup_input().degrade();
+        let btn2 = p0.p0_12.into_pullup_input().degrade();
+        let btn3 = p0.p0_24.into_pullup_input().degrade();
+        let btn4 = p0.p0_25.into_pullup_input().degrade();
+
+        let gpiote = Gpiote::new(ctx.device.GPIOTE);
+        gpiote.port().input_pin(&btn1).low();
+        gpiote.port().input_pin(&btn2).low();
+        gpiote.port().input_pin(&btn3).low();
+        gpiote.port().input_pin(&btn4).low();
+        gpiote.port().enable_interrupt();
+
+        let twim = Twim::new(ctx.device.TWIM0, Pins { scl, sda }, Frequency::K100);
+
+        init::LateResources {
+            twim,
+            gpiote,
+            btn1,
+            btn2,
+            btn3,
+            btn4,
+        }
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        rprintln!("Press button 1 to READ from addr 0x1A");
+        rprintln!("Press button 2 to WRITE to addr 0x1A");
+        rprintln!("Press button 3 to READ from addr 0x1B");
+        rprintln!("Press button 4 to WRITE from addr 0x1B");
+        loop {
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(binds = GPIOTE, resources = [gpiote], schedule = [debounce])]
+    fn on_gpiote(ctx: on_gpiote::Context) {
+        ctx.resources.gpiote.reset_events();
+        ctx.schedule.debounce(ctx.start + 3_000_000.cycles()).ok();
+    }
+
+    #[task(resources = [twim, gpiote, btn1, btn2, btn3, btn4])]
+    fn debounce(ctx: debounce::Context) {
+        let twim = ctx.resources.twim;
+        if ctx.resources.btn1.is_low().unwrap() {
+            rprintln!("\nREAD from address 0x1A");
+            let rx_buf = &mut [0; 8][..];
+            let res = twim.read(0x1A, rx_buf);
+            rprintln!("Result: {:?}\n{:?}", res, rx_buf);
+        }
+        if ctx.resources.btn2.is_low().unwrap() {
+            rprintln!("\nWRITE to address 0x1A");
+            let mut tx_buf = [0u8; 8];
+            tx_buf.copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+            let res = twim.write(0x1A, &tx_buf[..]);
+            rprintln!("Result: {:?}\n{:?}", res, tx_buf);
+        }
+        if ctx.resources.btn3.is_low().unwrap() {
+            rprintln!("\nREAD from address 0x1B");
+            let rx_buf = &mut [0; 4][..];
+            let res = twim.read(0x1B, rx_buf);
+            rprintln!("Result: {:?}\n{:?}", res, rx_buf);
+        }
+        if ctx.resources.btn4.is_low().unwrap() {
+            rprintln!("\nWRITE to address 0x1B");
+            let mut tx_buf = [0u8; 4];
+            tx_buf.copy_from_slice(&[9, 10, 11, 12]);
+            let res = twim.write(0x1B, &tx_buf[..]);
+            rprintln!("Result: {:?}\n{:?}", res, tx_buf);
+        }
+    }
+
+    extern "C" {
+        fn SWI0_EGU0();
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/examples/twim-demo/src/main.rs
+++ b/examples/twim-demo/src/main.rs
@@ -1,6 +1,8 @@
 #![no_std]
 #![no_main]
 
+#[allow(unused_imports)]
+use embedded_hal::blocking::i2c::{Read, Write};
 use embedded_hal::digital::v2::InputPin;
 use {
     core::{
@@ -18,7 +20,7 @@ use {
     rtt_target::{rprintln, rtt_init_print},
 };
 
-#[rtic::app(device = crate::hal::pac, peripherals = true,  monotonic = rtic::cyccnt::CYCCNT)]
+#[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {
     struct Resources {
         twim: Twim<TWIM0>,
@@ -91,8 +93,7 @@ const APP: () = {
         }
         if ctx.resources.btn2.is_low().unwrap() {
             rprintln!("\nWRITE to address 0x1A");
-            let mut tx_buf = [0u8; 8];
-            tx_buf.copy_from_slice(&[1, 2, 3, 4, 5, 6, 7, 8]);
+            let tx_buf = [1, 2, 3, 4, 5, 6, 7, 8];
             let res = twim.write(0x1A, &tx_buf[..]);
             rprintln!("Result: {:?}\n{:?}", res, tx_buf);
         }
@@ -104,8 +105,7 @@ const APP: () = {
         }
         if ctx.resources.btn4.is_low().unwrap() {
             rprintln!("\nWRITE to address 0x1B");
-            let mut tx_buf = [0u8; 4];
-            tx_buf.copy_from_slice(&[9, 10, 11, 12]);
+            let tx_buf = [9, 10, 11, 12];
             let res = twim.write(0x1B, &tx_buf[..]);
             rprintln!("Result: {:?}\n{:?}", res, tx_buf);
         }

--- a/examples/twis-demo/Cargo.toml
+++ b/examples/twis-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "twis-demo"
+version = "0.1.0"
+authors = ["Henrik Alsér"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rtic = "0.5.3"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/twis-demo/Embed.toml
+++ b/examples/twis-demo/Embed.toml
@@ -1,0 +1,46 @@
+[default.probe]
+# The index of the probe in the connected probe list.
+# probe_index = 0
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[default.flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after flashing.
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[default.general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used.
+log_level = "Warn"
+
+[default.rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+
+[default.gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/twis-demo/src/main.rs
+++ b/examples/twis-demo/src/main.rs
@@ -1,0 +1,120 @@
+#![no_std]
+#![no_main]
+
+use cortex_m::singleton;
+use embedded_hal::digital::v2::OutputPin;
+use {
+    core::{
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    hal::{
+        gpio::{Level, Output, Pin, PushPull},
+        pac::TWIS0,
+        twis::*,
+    },
+    nrf52840_hal as hal,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+const ADDR0: u8 = 0x1A;
+const ADDR1: u8 = 0x1B;
+const BUF0_SZ: usize = 8;
+const BUF1_SZ: usize = 4;
+
+#[rtic::app(device = crate::hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        twis: Twis<TWIS0>,
+        buffer0: &'static mut [u8; BUF0_SZ],
+        buffer1: &'static mut [u8; BUF1_SZ],
+        led: Pin<Output<PushPull>>,
+    }
+
+    #[init]
+    fn init(ctx: init::Context) -> init::LateResources {
+        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+        rtt_init_print!();
+
+        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let led = p0.p0_06.into_push_pull_output(Level::High).degrade();
+        let scl = p0.p0_14.into_floating_input().degrade();
+        let sda = p0.p0_16.into_floating_input().degrade();
+
+        let twis = Twis::new(ctx.device.TWIS0, Pins { scl, sda }, ADDR0);
+        twis.address1(ADDR1)
+            .enable_interrupt(TwiCommand::Write)
+            .enable_interrupt(TwiCommand::Read)
+            .enable();
+
+        let buffer0 = singleton!(: [u8; BUF0_SZ] = [0; BUF0_SZ]).unwrap();
+        let buffer1 = singleton!(: [u8; BUF1_SZ] = [0; BUF1_SZ]).unwrap();
+        init::LateResources {
+            twis,
+            buffer0,
+            buffer1,
+            led,
+        }
+    }
+
+    #[idle]
+    fn idle(_: idle::Context) -> ! {
+        rprintln!("Waiting for commands from controller...");
+        loop {
+            cortex_m::asm::wfi();
+        }
+    }
+
+    #[task(binds = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0, resources = [twis, buffer0, buffer1, led])]
+    fn on_twis(ctx: on_twis::Context) {
+        let twis = ctx.resources.twis;
+        let buffer0 = ctx.resources.buffer0;
+        let buffer1 = ctx.resources.buffer1;
+        let led = ctx.resources.led;
+
+        if twis.is_read() {
+            twis.reset_read_event();
+            led.set_low().ok();
+            rprintln!("\nREAD cmd received on addr 0x{:x}", twis.address_match());
+            rprintln!("Writing data to controller...");
+            match twis.address_match() {
+                ADDR0 => {
+                    let res = twis.write(&buffer0[..]);
+                    rprintln!("Result: {:?}\n{:?}", res, buffer0);
+                }
+                ADDR1 => {
+                    let res = twis.write(&buffer1[..]);
+                    rprintln!("Result: {:?}\n{:?}", res, buffer1);
+                }
+                _ => unreachable!(),
+            }
+        }
+        if twis.is_write() {
+            twis.reset_write_event();
+            led.set_high().ok();
+            rprintln!("\nWRITE cmd received on addr 0x{:x}", twis.address_match());
+            rprintln!("Reading data from controller...");
+            match twis.address_match() {
+                ADDR0 => {
+                    let res = twis.read(&mut buffer0[..]);
+                    rprintln!("Result: {:?}\n{:?}", res, buffer0);
+                }
+                ADDR1 => {
+                    let res = twis.read(&mut buffer1[..]);
+                    rprintln!("Result: {:?}\n{:?}", res, buffer1);
+                }
+                _ => unreachable!(),
+            }
+        }
+    }
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    rprintln!("{}", info);
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -56,6 +56,8 @@ pub mod timer;
 pub mod twi;
 #[cfg(not(feature = "51"))]
 pub mod twim;
+#[cfg(not(any(feature = "51", feature = "9160")))]
+pub mod twis;
 #[cfg(feature = "51")]
 pub mod uart;
 #[cfg(not(feature = "51"))]

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -1,0 +1,328 @@
+//! HAL interface to the TWIS peripheral.
+//!
+
+use core::ops::Deref;
+use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
+
+use crate::pac::{twis0, P0, TWIS0};
+
+#[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
+use crate::pac::TWIS1;
+
+use crate::pac::{
+    generic::Reg,
+    twis0::{_EVENTS_READ, _EVENTS_STOPPED, _EVENTS_WRITE, _TASKS_STOP},
+};
+
+use crate::{
+    gpio::{Floating, Input, Pin},
+    slice_in_ram_or,
+    target_constants::EASY_DMA_SIZE,
+};
+
+/// Interface to a TWIS instance.
+pub struct Twis<T>(T);
+
+impl<T> Twis<T>
+where
+    T: Instance,
+{
+    pub fn new(twis: T, pins: Pins, address0: u8) -> Self {
+        // The TWIS peripheral requires the pins to be in a mode that is not
+        // exposed through the GPIO API, and might it might not make sense to
+        // expose it there.
+        //
+        // Until we've figured out what to do about this, let's just configure
+        // the pins through the raw peripheral API. All of the following is
+        // safe, as we own the pins now and have exclusive access to their
+        // registers.
+        for &pin in &[pins.scl.pin(), pins.sda.pin()] {
+            unsafe { &*P0::ptr() }.pin_cnf[pin as usize].write(|w| {
+                w.dir()
+                    .input()
+                    .input()
+                    .connect()
+                    .pull()
+                    .pullup()
+                    .drive()
+                    .s0d1()
+                    .sense()
+                    .disabled()
+            });
+        }
+
+        twis.psel.scl.write(|w| {
+            let w = unsafe { w.pin().bits(pins.scl.pin()) };
+            #[cfg(feature = "52840")]
+            let w = w.port().bit(pins.scl.port().bit());
+            w.connect().connected()
+        });
+        twis.psel.sda.write(|w| {
+            let w = unsafe { w.pin().bits(pins.sda.pin()) };
+            #[cfg(feature = "52840")]
+            let w = w.port().bit(pins.sda.port().bit());
+            w.connect().connected()
+        });
+
+        twis.address[0].write(|w| unsafe { w.address().bits(address0) });
+        twis.config.modify(|_r, w| w.address0().enabled());
+
+        Twis(twis)
+    }
+
+    /// Configures secondary I2C address.
+    #[inline(always)]
+    pub fn address1(&self, address1: u8) -> &Self {
+        self.0.address[1].write(|w| unsafe { w.address().bits(address1) });
+        self.0.config.modify(|_r, w| w.address1().enabled());
+        self
+    }
+
+    /// Sets ORC.
+    #[inline(always)]
+    pub fn orc(&self, orc: u8) -> &Self {
+        self.0.orc.write(|w| unsafe { w.orc().bits(orc) });
+        self
+    }
+
+    /// Enables the TWIS instance.
+    #[inline(always)]
+    pub fn enable(&self) {
+        self.0.enable.write(|w| w.enable().enabled());
+    }
+
+    /// Enables interrupt for specified command.
+    #[inline(always)]
+    pub fn enable_interrupt(&self, command: TwiCommand) -> &Self {
+        self.0.intenset.modify(|_r, w| match command {
+            TwiCommand::Read => w.read().set_bit(),
+            TwiCommand::Write => w.write().set_bit(),
+        });
+        self
+    }
+
+    /// Disables interrupt for specified command.
+    #[inline(always)]
+    pub fn disable_interrupt(&self, command: TwiCommand) -> &Self {
+        self.0.intenclr.write(|w| match command {
+            TwiCommand::Read => w.read().set_bit(),
+            TwiCommand::Write => w.write().set_bit(),
+        });
+        self
+    }
+
+    /// Resets read and write events.
+    #[inline(always)]
+    pub fn reset_events(&self) {
+        self.0.events_read.write(|w| w);
+        self.0.events_write.write(|w| w);
+    }
+
+    /// Resets read events.
+    #[inline(always)]
+    pub fn reset_read_event(&self) {
+        self.0.events_read.write(|w| w);
+    }
+
+    /// Resets write events.
+    #[inline(always)]
+    pub fn reset_write_event(&self) {
+        self.0.events_write.write(|w| w);
+    }
+
+    /// Returns matched address for latest command.
+    #[inline(always)]
+    pub fn address_match(&self) -> u8 {
+        self.0.address[self.0.match_.read().match_().bits() as usize]
+            .read()
+            .address()
+            .bits()
+    }
+
+    /// Checks if read event has been triggered.
+    #[inline(always)]
+    pub fn is_read(&self) -> bool {
+        self.0.events_read.read().bits() != 0
+    }
+
+    /// Checks if write event has been triggered.
+    #[inline(always)]
+    pub fn is_write(&self) -> bool {
+        self.0.events_write.read().bits() != 0
+    }
+
+    /// Returns reference to `READ` event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_read(&self) -> &Reg<u32, _EVENTS_READ> {
+        &self.0.events_read
+    }
+
+    /// Returns reference to `WRITE` event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_write(&self) -> &Reg<u32, _EVENTS_WRITE> {
+        &self.0.events_write
+    }
+
+    /// Returns reference to `STOPPED` event endpoint for PPI.
+    #[inline(always)]
+    pub fn event_stopped(&self) -> &Reg<u32, _EVENTS_STOPPED> {
+        &self.0.events_stopped
+    }
+
+    /// Returns reference to `STOP` task endpoint for PPI.
+    #[inline(always)]
+    pub fn task_stop(&self) -> &Reg<u32, _TASKS_STOP> {
+        &self.0.tasks_stop
+    }
+
+    /// Write to an I2C controller.
+    ///
+    /// The buffer must reside in RAM and have a length of at most
+    /// 255 bytes on the nRF52832 and at most 65535 bytes on the nRF52840.
+    pub fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        slice_in_ram_or(buffer, Error::DMABufferNotInDataMemory)?;
+
+        if buffer.len() > EASY_DMA_SIZE {
+            return Err(Error::TxBufferTooLong);
+        }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started.
+        compiler_fence(SeqCst);
+
+        // Set up the DMA write.
+        self.0
+            .txd
+            .ptr
+            .write(|w| unsafe { w.ptr().bits(buffer.as_ptr() as u32) });
+        self.0
+            .txd
+            .maxcnt
+            .write(|w| unsafe { w.maxcnt().bits(buffer.len() as _) });
+
+        // Clear errors.
+        self.0.errorsrc.write(|w| w);
+
+        // Start write operation.
+        self.0.tasks_preparetx.write(|w| unsafe { w.bits(1) });
+
+        // Wait until write operation has ended.
+        while self.0.events_stopped.read().bits() == 0 {}
+        self.0.events_stopped.write(|w| w); // reset event
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // after all possible DMA actions have completed.
+        compiler_fence(SeqCst);
+
+        if self.0.errorsrc.read().dnack().bits() {
+            return Err(Error::DataNack);
+        }
+
+        if self.0.errorsrc.read().overflow().bits() {
+            return Err(Error::OverFlow);
+        }
+
+        if self.0.txd.amount.read().bits() != buffer.len() as u32 {
+            return Err(Error::Transmit);
+        }
+
+        Ok(())
+    }
+
+    /// Read from an I2C controller.
+    ///
+    /// The buffer must have a length of at most 255 bytes on the nRF52832
+    /// and at most 65535 bytes on the nRF52840.
+    pub fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        // NOTE: RAM slice check is not necessary, as a mutable slice can only be
+        // built from data located in RAM.
+
+        if buffer.len() > EASY_DMA_SIZE {
+            return Err(Error::RxBufferTooLong);
+        }
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // before any DMA action has started.
+        compiler_fence(SeqCst);
+
+        // Set up the DMA read.
+        self.0
+            .rxd
+            .ptr
+            .write(|w| unsafe { w.ptr().bits(buffer.as_mut_ptr() as u32) });
+        self.0
+            .rxd
+            .maxcnt
+            .write(|w| unsafe { w.maxcnt().bits(buffer.len() as _) });
+
+        // Clear errors.
+        self.0.errorsrc.write(|w| w);
+
+        // Start read operation.
+        self.0.tasks_preparerx.write(|w| unsafe { w.bits(1) });
+
+        // Wait until read operation has ended.
+        while self.0.events_stopped.read().bits() == 0 {}
+        self.0.events_stopped.write(|w| w); // reset event
+
+        // Conservative compiler fence to prevent optimizations that do not
+        // take in to account actions by DMA. The fence has been placed here,
+        // after all possible DMA actions have completed.
+        compiler_fence(SeqCst);
+
+        if self.0.errorsrc.read().overread().bits() {
+            return Err(Error::OverRead);
+        }
+
+        if self.0.rxd.amount.read().bits() != buffer.len() as u32 {
+            return Err(Error::Receive);
+        }
+
+        Ok(())
+    }
+
+    /// Return the raw interface to the underlying TWIS peripheral.
+    pub fn free(self) -> T {
+        self.0
+    }
+}
+
+/// The pins used by the TWIS peripheral.
+///
+/// Currently, only P0 pins are supported.
+pub struct Pins {
+    // Serial Clock Line.
+    pub scl: Pin<Input<Floating>>,
+
+    // Serial Data Line.
+    pub sda: Pin<Input<Floating>>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    TxBufferTooLong,
+    RxBufferTooLong,
+    Transmit,
+    Receive,
+    DMABufferNotInDataMemory,
+    DataNack,
+    OverFlow,
+    OverRead,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+pub enum TwiCommand {
+    Read,
+    Write,
+}
+
+/// Implemented by all TWIS instances
+pub trait Instance: Deref<Target = twis0::RegisterBlock> {}
+
+impl Instance for TWIS0 {}
+
+#[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
+impl Instance for TWIS1 {}

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -93,20 +93,20 @@ where
 
     /// Enables interrupt for specified command.
     #[inline(always)]
-    pub fn enable_interrupt(&self, command: TwiCommand) -> &Self {
+    pub fn enable_interrupt(&self, command: TwiEvent) -> &Self {
         self.0.intenset.modify(|_r, w| match command {
-            TwiCommand::Read => w.read().set_bit(),
-            TwiCommand::Write => w.write().set_bit(),
+            TwiEvent::Read => w.read().set_bit(),
+            TwiEvent::Write => w.write().set_bit(),
         });
         self
     }
 
     /// Disables interrupt for specified command.
     #[inline(always)]
-    pub fn disable_interrupt(&self, command: TwiCommand) -> &Self {
+    pub fn disable_interrupt(&self, command: TwiEvent) -> &Self {
         self.0.intenclr.write(|w| match command {
-            TwiCommand::Read => w.read().set_bit(),
-            TwiCommand::Write => w.write().set_bit(),
+            TwiEvent::Read => w.read().set_bit(),
+            TwiEvent::Write => w.write().set_bit(),
         });
         self
     }
@@ -118,16 +118,13 @@ where
         self.0.events_write.write(|w| w);
     }
 
-    /// Resets read events.
+    /// Resets specified event.
     #[inline(always)]
-    pub fn reset_read_event(&self) {
-        self.0.events_read.write(|w| w);
-    }
-
-    /// Resets write events.
-    #[inline(always)]
-    pub fn reset_write_event(&self) {
-        self.0.events_write.write(|w| w);
+    pub fn reset_event(&self, event: TwiEvent) {
+        match event {
+            TwiEvent::Read => self.0.events_read.write(|w| w),
+            TwiEvent::Write => self.0.events_write.write(|w| w),
+        };
     }
 
     /// Returns matched address for latest command.
@@ -139,16 +136,13 @@ where
             .bits()
     }
 
-    /// Checks if read event has been triggered.
+    /// Checks if specified event has been triggered.
     #[inline(always)]
-    pub fn is_read(&self) -> bool {
-        self.0.events_read.read().bits() != 0
-    }
-
-    /// Checks if write event has been triggered.
-    #[inline(always)]
-    pub fn is_write(&self) -> bool {
-        self.0.events_write.read().bits() != 0
+    pub fn is_event_triggered(&self, event: TwiEvent) -> bool {
+        match event {
+            TwiEvent::Read => self.0.events_read.read().bits() != 0,
+            TwiEvent::Write => self.0.events_write.read().bits() != 0,
+        }
     }
 
     /// Returns reference to `READ` event endpoint for PPI.
@@ -314,7 +308,7 @@ pub enum Error {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
-pub enum TwiCommand {
+pub enum TwiEvent {
     Read,
     Write,
 }


### PR DESCRIPTION
Added a HAL module for TWIS (I2C compatible two-wire interface peripheral, formerly referred to as an "I2C slave")

Here's a demo showing read and write operations using interrupts and multiple I2C addresses (ItsyBitsy nRF52840):
https://github.com/kalkyl/nrf-hal/blob/twis/examples/twis-demo/src/main.rs

Also added a TWIM demo that can also be used together with the above TWIS demo, to show the corresponding controller code (nRF52840-DK):
https://github.com/kalkyl/nrf-hal/blob/twis/examples/twim-demo/src/main.rs
