### PR TITLE
Refuse to build nRF52+ HALs for thumbv6

### DIFF
--- a/nrf-hal-common/build.rs
+++ b/nrf-hal-common/build.rs
@@ -1,0 +1,15 @@
+use std::{env, process};
+
+fn main() {
+    if env::var_os("CARGO_FEATURE_51").is_none() {
+        // Not building for the nRF51. 52+ use too many interrupts for the thumbv6 target, so detect
+        // that early.
+        if env::var("TARGET").unwrap() == "thumbv6m-none-eabi" {
+            eprintln!(
+                "the nRF HAL does not support the `thumbv6m-none-eabi` target; \
+                build for `thumbv7em-none-eabi(hf)` instead"
+            );
+            process::exit(1);
+        }
+    }
+}

--- a/nrf-hal-common/build.rs
+++ b/nrf-hal-common/build.rs
@@ -6,7 +6,7 @@ fn main() {
         // that early.
         if env::var("TARGET").unwrap() == "thumbv6m-none-eabi" {
             eprintln!(
-                "the nRF HAL does not support the `thumbv6m-none-eabi` target; \
+                "this nRF device does not support the `thumbv6m-none-eabi` target; \
                 build for `thumbv7em-none-eabi(hf)` instead"
             );
             process::exit(1);


### PR DESCRIPTION
This currently fails with a not-so-obvious linker error from the cortex-m-rt linker script, since the chips have more than 32 interrupts (the limit of thumbv6).