### PR TITLE
Prevent building for subtly incompatible targets

### DIFF
--- a/nrf51-hal/build.rs
+++ b/nrf51-hal/build.rs
@@ -4,6 +4,14 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
+    if !target.starts_with("thumbv6") {
+        panic!(
+            "nrf51-hal only supports thumbv6 targets (attempting to build for `{}`)",
+            target
+        );
+    }
+
     if let Some((flash, mem)) = memory_sizes() {
         let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
 

--- a/nrf52810-hal/build.rs
+++ b/nrf52810-hal/build.rs
@@ -4,6 +4,11 @@ use std::io::Write;
 use std::path::PathBuf;
 
 fn main() {
+    let target = env::var("TARGET").unwrap();
+    if target.ends_with("eabihf") {
+        panic!("attempting to build nrf52810-hal for target `{}`, but the nRF52810 does not have an FPU", target);
+    }
+
     // Put the linker script somewhere the linker can find it
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     File::create(out.join("memory.x"))

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,7 +21,7 @@ cargo build --manifest-path nrf52840-hal/Cargo.toml
 # Build all the example projects.
 
 echo Building examples/ccm-demo...
-cargo build --manifest-path examples/ccm-demo/Cargo.toml --features=52810
+cargo build --manifest-path examples/ccm-demo/Cargo.toml --features=52810 --target thumbv7em-none-eabi
 cargo build --manifest-path examples/ccm-demo/Cargo.toml --features=52832
 cargo build --manifest-path examples/ccm-demo/Cargo.toml --features=52833
 cargo build --manifest-path examples/ccm-demo/Cargo.toml --features=52840
@@ -30,11 +30,11 @@ echo Building examples/comp-demo...
 cargo build --manifest-path examples/comp-demo/Cargo.toml
 
 echo Building examples/ecb-demo...
-cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=52810
+cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=52810 --target thumbv7em-none-eabi
 cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=52832
 cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=52833
 cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=52840
-cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=51
+cargo build --manifest-path examples/ecb-demo/Cargo.toml --features=51 --target thumbv6m-none-eabi
 
 echo Building examples/gpiote-demo...
 cargo build --manifest-path examples/gpiote-demo/Cargo.toml
@@ -50,8 +50,8 @@ echo Building examples/lpcomp-demo...
 cargo build --manifest-path examples/lpcomp-demo/Cargo.toml
 
 echo Building examples/ppi-demo...
-cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=51
-cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=52810
+cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=51 --target thumbv6m-none-eabi
+cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=52810 --target thumbv7em-none-eabi
 cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=52832
 cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=52833
 cargo build --manifest-path examples/ppi-demo/Cargo.toml --features=52840


### PR DESCRIPTION
Turns out we were doing that in the CI script. Also, the nRF52810 is the only nRF52 without an FPU, which is pretty subtle. Detect those cases and abort the build.