### PR TITLE
Use DMA Transfer API in I2S module

### DIFF
--- a/examples/i2s-controller-demo/src/main.rs
+++ b/examples/i2s-controller-demo/src/main.rs
@@ -33,10 +33,7 @@ use {
 #[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {
     struct Resources {
-        // i2s: hal::i2s::I2S,
-        // #[init([0; 32])]
         signal_buf: pin::Pin<&'static [i16]>,
-        // #[init([0; 32])]
         mute_buf: pin::Pin<&'static [i16]>,
         #[init(None)]
         queue: Option<Queue<State, U256>>,
@@ -57,6 +54,7 @@ const APP: () = {
     fn init(mut ctx: init::Context) -> init::LateResources {
         static mut MUTE_BUF: [i16; 32] = [0i16; 32];
         static mut SIGNAL_BUF: [i16; 32] = [0i16; 32];
+
         // Fill signal buffer with triangle waveform, 2 channels interleaved
         let len = SIGNAL_BUF.len() / 2;
         for x in 0..len {

--- a/examples/i2s-controller-demo/src/main.rs
+++ b/examples/i2s-controller-demo/src/main.rs
@@ -14,7 +14,6 @@ use small_morse::{encode, State};
 use {
     core::{
         panic::PanicInfo,
-        pin,
         sync::atomic::{compiler_fence, Ordering},
     },
     hal::{
@@ -33,8 +32,8 @@ use {
 #[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
 const APP: () = {
     struct Resources {
-        signal_buf: pin::Pin<&'static [i16]>,
-        mute_buf: pin::Pin<&'static [i16]>,
+        signal_buf: &'static [i16],
+        mute_buf: &'static [i16],
         #[init(None)]
         queue: Option<Queue<State, U256>>,
         producer: Producer<'static, State, U256>,
@@ -47,7 +46,7 @@ const APP: () = {
         btn1: Pin<Input<PullUp>>,
         btn2: Pin<Input<PullUp>>,
         led: Pin<Output<PushPull>>,
-        transfer: Option<hal::i2s::Transfer<&'static [i16]>>,
+        transfer: Option<Transfer<&'static [i16]>>,
     }
 
     #[init(resources = [queue], spawn = [tick])]
@@ -125,9 +124,9 @@ const APP: () = {
             led: p0.p0_13.into_push_pull_output(Level::High).degrade(),
             uarte,
             uarte_timer: Timer::new(ctx.device.TIMER0),
-            transfer: i2s.tx(pin::Pin::new(&MUTE_BUF[..])).ok(),
-            signal_buf: pin::Pin::new(&SIGNAL_BUF[..]),
-            mute_buf: pin::Pin::new(&MUTE_BUF[..]),
+            transfer: i2s.tx(&MUTE_BUF[..]).ok(),
+            signal_buf: &SIGNAL_BUF[..],
+            mute_buf: &MUTE_BUF[..],
         }
     }
 

--- a/examples/i2s-peripheral-demo/Cargo.toml
+++ b/examples/i2s-peripheral-demo/Cargo.toml
@@ -12,8 +12,6 @@ cortex-m = "0.6.2"
 cortex-m-rtic = "0.5.3"
 rtt-target = {version = "0.2.0", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
-small_morse = "0.1.0"
-m = "0.1.1"
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/examples/i2s-peripheral-demo/src/main.rs
+++ b/examples/i2s-peripheral-demo/src/main.rs
@@ -29,12 +29,12 @@ const RED: [u8; 9] = [0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x10, 0xFF];
 const APP: () = {
     struct Resources {
         rgb: Spim<SPIM0>,
-        transfer: Option<Transfer<&'static mut [i16]>>,
+        transfer: Option<Transfer<&'static mut [i16; 128]>>,
     }
 
     #[init]
     fn init(ctx: init::Context) -> init::LateResources {
-        static mut RX_BUF: [i16; 128] = [0i16; 128];
+        static mut RX_BUF: [i16; 128] = [0; 128];
 
         let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
         rtt_init_print!();
@@ -78,7 +78,7 @@ const APP: () = {
         );
         init::LateResources {
             rgb,
-            transfer: i2s.rx(&mut RX_BUF[..]).ok(),
+            transfer: i2s.rx(RX_BUF).ok(),
         }
     }
 
@@ -87,7 +87,7 @@ const APP: () = {
         let (rx_buf, i2s) = ctx.resources.transfer.take().unwrap().wait();
         if i2s.is_event_triggered(I2SEvent::RxPtrUpdated) {
             i2s.reset_event(I2SEvent::RxPtrUpdated);
-            // Calculate mono summed average of received buffer
+            //Calculate mono summed average of received buffer
             let avg = (rx_buf.iter().map(|x| (*x).abs() as u32).sum::<u32>() / rx_buf.len() as u32)
                 as u16;
             let color = match avg {

--- a/examples/i2s-peripheral-demo/src/main.rs
+++ b/examples/i2s-peripheral-demo/src/main.rs
@@ -2,13 +2,13 @@
 #![no_main]
 
 // I2S `peripheral mode` demo
-// RMS level indicator using an RGB LED (APA102 on ItsyBitsy nRF52840)
+// Signal average level indicator using an RGB LED (APA102 on ItsyBitsy nRF52840)
 
 use embedded_hal::blocking::spi::Write;
-use m::Float;
 use {
     core::{
         panic::PanicInfo,
+        pin,
         sync::atomic::{compiler_fence, Ordering},
     },
     hal::{
@@ -29,14 +29,14 @@ const RED: [u8; 9] = [0x00, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x10, 0xFF];
 #[rtic::app(device = crate::hal::pac, peripherals = true)]
 const APP: () = {
     struct Resources {
-        i2s: I2S,
-        #[init([0; 128])]
-        rx_buf: [i16; 128],
         rgb: Spim<SPIM0>,
+        transfer: Option<hal::i2s::Transfer<&'static mut [i16]>>,
     }
 
-    #[init(resources = [rx_buf])]
+    #[init]
     fn init(ctx: init::Context) -> init::LateResources {
+        static mut RX_BUF: [i16; 128] = [0i16; 128];
+
         let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
         rtt_init_print!();
         rprintln!("Play me some audio...");
@@ -56,10 +56,9 @@ const APP: () = {
             Some(&sdin_pin),
             None,
         );
-        i2s.enable_interrupt(I2SEvent::RxPtrUpdated)
-            .rx_buffer(&mut ctx.resources.rx_buf[..])
-            .ok();
-        i2s.enable().start();
+        i2s.enable_interrupt(I2SEvent::RxPtrUpdated).start();
+        let rx_buf = pin::Pin::new(&mut RX_BUF[..]);
+        let transfer = i2s.rx(rx_buf).ok();
 
         // Configure APA102 RGB LED control
         let p1 = hal::gpio::p1::Parts::new(ctx.device.P1);
@@ -80,28 +79,26 @@ const APP: () = {
             },
             0,
         );
-
-        init::LateResources { i2s, rgb }
+        init::LateResources { rgb, transfer }
     }
 
-    #[task(binds = I2S, resources = [i2s, rx_buf, rgb])]
+    #[task(binds = I2S, resources = [rgb, transfer])]
     fn on_i2s(ctx: on_i2s::Context) {
-        let on_i2s::Resources { i2s, rx_buf, rgb } = ctx.resources;
+        let (rx_buf, i2s) = ctx.resources.transfer.take().unwrap().wait();
         if i2s.is_event_triggered(I2SEvent::RxPtrUpdated) {
             i2s.reset_event(I2SEvent::RxPtrUpdated);
-            // Calculate mono summed RMS of received buffer
-            let rms = Float::sqrt(
-                (rx_buf.iter().map(|x| *x as i32).map(|x| x * x).sum::<i32>() / rx_buf.len() as i32)
-                    as f32,
-            ) as u16;
-            let color = match rms {
+            // Calculate mono summed average of received buffer
+            let avg = (rx_buf.iter().map(|x| (*x).abs() as u32).sum::<u32>() / rx_buf.len() as u32)
+                as u16;
+            let color = match avg {
                 0..=4 => &OFF,
                 5..=10_337 => &GREEN,
                 10_338..=16_383 => &ORANGE,
                 _ => &RED,
             };
-            <Spim<SPIM0> as Write<u8>>::write(rgb, color).ok();
+            <Spim<SPIM0> as Write<u8>>::write(ctx.resources.rgb, color).ok();
         }
+        *ctx.resources.transfer = i2s.rx(rx_buf).ok();
     }
 };
 

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -25,6 +25,10 @@ fixed = "1.0.0"
 rand_core = "0.5.1"
 cfg-if = "0.1.10"
 
+[dependencies.stable_deref_trait]
+version = "1.2.0"
+default-features = false
+
 [dependencies.void]
 default-features = false
 version = "1.0.2"

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -24,10 +24,7 @@ nb = "1.0.0"
 fixed = "1.0.0"
 rand_core = "0.5.1"
 cfg-if = "0.1.10"
-
-[dependencies.stable_deref_trait]
-version = "1.2.0"
-default-features = false
+embedded-dma = "0.1.1"
 
 [dependencies.void]
 default-features = false


### PR DESCRIPTION
I changed the I2S module to use a DMA `Transfer` API for TX and RX operations.
I also added support for full duplex transfers and the demos were updated according to the new API.

"Controller mode" demo (TX):
https://github.com/kalkyl/nrf-hal/blob/i2s-dma/examples/i2s-controller-demo/src/main.rs

"Peripheral mode" demo (RX):
https://github.com/kalkyl/nrf-hal/blob/i2s-dma/examples/i2s-peripheral-demo/src/main.rs