### PR TITLE
Implement `cargo xtask bump` for bumping versions

### DIFF
--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -1,6 +1,7 @@
 //! Implementation details of the nRF HAL crates. Don't use this directly, use one of the specific
 //! HAL crates instead (`nrfXYZ-hal`).
 
+#![doc(html_root_url = "https://docs.rs/nrf-hal-common/0.11.1")]
 #![no_std]
 
 use embedded_hal as hal;

--- a/nrf51-hal/Cargo.toml
+++ b/nrf51-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf51-hal"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 description = "HAL for nRF51 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -23,7 +23,7 @@ nrf51 = "0.9.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["51"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf51-hal/src/lib.rs
+++ b/nrf51-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf51-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -22,7 +22,7 @@ nrf52810-pac = "0.9.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52810"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf52810-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.11.0"
+version = "0.11.1"
 description = "HAL for nRF52832 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -21,7 +21,7 @@ nrf52832-pac = "0.9.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52832"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf52832-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/nrf52833-hal/Cargo.toml
+++ b/nrf52833-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52833-hal"
-version = "0.11.0"
+version = "0.11.1"
 description = "HAL for nRF52833 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -24,7 +24,7 @@ nrf52833-pac = "0.9.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52833"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52833-hal/src/lib.rs
+++ b/nrf52833-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf52833-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.11.0"
+version = "0.11.1"
 description = "HAL for nRF52840 microcontrollers"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -23,7 +23,7 @@ nrf52840-pac = "0.9.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52840"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf52840-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf9160-hal"
-version = "0.11.0"
+version = "0.11.1"
 description = "HAL for nRF9160 system-in-package"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
@@ -20,7 +20,7 @@ nrf9160-pac = "0.2.0"
 path = "../nrf-hal-common"
 default-features = false
 features = ["9160"]
-version = "0.11.0"
+version = "=0.11.1"
 
 [dependencies.embedded-hal]
 features = ["unproven"]

--- a/nrf9160-hal/src/lib.rs
+++ b/nrf9160-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf9160-hal/0.11.1")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,0 +1,18 @@
+use std::env;
+
+fn main() {
+    let mut args = env::args().skip(1);
+    let subcommand = args.next();
+    match subcommand.as_deref() {
+        Some("bump") => {
+            let new_version = args.next().expect("missing <semver> argument");
+            xtask::bump_versions(&new_version, false);
+        }
+        _ => {
+            eprintln!("usage: cargo xtask <subcommand>");
+            eprintln!();
+            eprintln!("subcommands:");
+            eprintln!("    bump <semver> - bump crate versions to <semver>");
+        }
+    }
+}

--- a/xtask/tests/ci.rs
+++ b/xtask/tests/ci.rs
@@ -28,6 +28,9 @@ fn main() {
     // We execute from the `xtask` dir, so `cd ..` so that we can find `examples` etc.
     env::set_current_dir("..").unwrap();
 
+    // Make sure all the tomls are formatted in a way that's compatible with our tooling.
+    xtask::bump_versions("0.0.0", true);
+
     // Build-test every HAL.
     for (hal, target) in HALS {
         let mut cargo = Command::new("cargo");


### PR DESCRIPTION
This can be used to automatically bump all crate versions, as well as the changelog version, to the specified version, which reduces the work to publish a new version of the HAL.

Closes #198 (I've added `html_root_url` and it is now automatically updated)