### PR TITLE
PPI channel group tasks

### DIFF
--- a/nrf-hal-common/src/ppi/mod.rs
+++ b/nrf-hal-common/src/ppi/mod.rs
@@ -93,7 +93,7 @@ pub trait ConfigurablePpi {
 pub trait PpiChannelGroup {
     /// Returns reference to `tasks_chg[x].en` endpoint for enabling channel group.
     fn task_enable(&self) -> &Reg<u32, _EN>;
-    /// Returns reference to tasks_chg[x].dis endpoint for disabling channel group.
+    /// Returns reference to `tasks_chg[x].dis` endpoint for disabling channel group.
     fn task_disable(&self) -> &Reg<u32, _DIS>;
     /// Sets bitmask for PPI channels which shall be included in this channel group.
     fn set_channels(&self, mask: u32);

--- a/nrf-hal-common/src/ppi/mod.rs
+++ b/nrf-hal-common/src/ppi/mod.rs
@@ -91,7 +91,7 @@ pub trait ConfigurablePpi {
 
 /// Trait for a PPI channel group.
 pub trait PpiChannelGroup {
-    /// Returns reference to tasks_chg[x].en endpoint for enabling channel group.
+    /// Returns reference to `tasks_chg[x].en` endpoint for enabling channel group.
     fn task_enable(&self) -> &Reg<u32, _EN>;
     /// Returns reference to tasks_chg[x].dis endpoint for disabling channel group.
     fn task_disable(&self) -> &Reg<u32, _DIS>;

--- a/nrf-hal-common/src/ppi/task_nrf52832.rs
+++ b/nrf-hal-common/src/ppi/task_nrf52832.rs
@@ -1,5 +1,9 @@
 use crate::ppi::Task;
 
+// Task Impls for PPI channel groups
+impl Task for crate::pac::ppi::tasks_chg::EN {}
+impl Task for crate::pac::ppi::tasks_chg::DIS {}
+
 // Task Impls
 //
 // To reproduce, in the pac crate, search


### PR DESCRIPTION
This adds channel groups to the ppi::Parts for accessing the PPI channel group tasks.