### PR TITLE
Adding Port on GPIOTE Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Refuse to build nRF52+ HALs for thumbv6m targets ([#203]).
 - Refuse to build `nrf52810-hal` for hard-float targets, and `nrf51-hal` for thumbv7+ targets
   ([#206]).
+- GPIOTE Port 1 and 0 differentiation for nRF52833 and nRF52840 ([#217])
 
 ### Breaking Changes
 
@@ -32,6 +33,7 @@
 [#203]: https://github.com/nrf-rs/nrf-hal/pull/203
 [#190]: https://github.com/nrf-rs/nrf-hal/pull/190
 [#206]: https://github.com/nrf-rs/nrf-hal/pull/206
+[#217]: https://github.com/nrf-rs/nrf-hal/pull/217
 
 ## [0.11.1]
 

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -257,6 +257,15 @@ fn config_channel_event_pin<P: GpioteInputPin>(
             EventPolarity::None => w.mode().event().polarity().none(),
             EventPolarity::Toggle => w.mode().event().polarity().toggle(),
         };
+
+        #[cfg(any(feature = "52833", feature = "52840"))]
+        {
+            match pin.port() {
+                Port::Port0 => w.port().clear_bit(),
+                Port::Port1 => w.port().set_bit(),
+            };
+        }
+
         unsafe { w.psel().bits(pin.pin()) }
     });
 }


### PR DESCRIPTION
The Configuration of the GPIOTE needs the Port to be set (on devices
with multiple ports)
This resolves #216 .

Signed-off-by: trembel <silvano.cortesi@hotmail.com>