### PR TITLE
Exclude .DS_Store from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "nrf9160-hal",
   "examples/*",
 ]
+exclude = ["examples/.DS_Store"]
 
 [profile.dev]
 incremental = false


### PR DESCRIPTION
Apparently the glob includes dotfiles, which seems like a Cargo bug. Explicitly exclude `.DS_Store` to fix building on macOS.