### PR TITLE
Add 'static lifetime bounds to SPIS DMA buffers

### DIFF
--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -420,6 +420,7 @@ where
 
 /// A DMA transfer
 pub struct Transfer<T: Instance, B> {
+    // FIXME: Always `Some`, only using `Option` here to allow moving fields out of `inner`.
     inner: Option<Inner<T, B>>,
 }
 
@@ -463,6 +464,7 @@ impl<T: Instance, B> Drop for Transfer<T, B> {
 }
 /// A full duplex DMA transfer
 pub struct TransferSplit<T: Instance, TxB, RxB> {
+    // FIXME: Always `Some`, only using `Option` here to allow moving fields out of `inner`.
     inner: Option<InnerSplit<T, TxB, RxB>>,
 }
 
@@ -490,7 +492,7 @@ impl<T: Instance, TxB, RxB> TransferSplit<T, TxB, RxB> {
     pub fn is_done(&mut self) -> bool {
         let inner = self
             .inner
-            .take()
+            .as_mut()
             .unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
         inner.spis.is_done()
     }
@@ -498,7 +500,7 @@ impl<T: Instance, TxB, RxB> TransferSplit<T, TxB, RxB> {
 
 impl<T: Instance, TxB, RxB> Drop for TransferSplit<T, TxB, RxB> {
     fn drop(&mut self) {
-        if let Some(inner) = self.inner.as_mut() {
+        if let Some(inner) = self.inner.take() {
             compiler_fence(Ordering::SeqCst);
             while !inner.spis.is_done() {}
             inner.spis.disable();

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -328,7 +328,7 @@ where
     #[allow(unused_mut)]
     pub fn transfer<W, B>(mut self, mut buffer: B) -> Result<Transfer<T, B>, (Error, Spis<T>, B)>
     where
-        B: WriteBuffer<Word = W>,
+        B: WriteBuffer<Word = W> + 'static,
     {
         let (ptr, len) = unsafe { buffer.write_buffer() };
         let maxcnt = len * core::mem::size_of::<W>();
@@ -371,8 +371,8 @@ where
         mut rx_buffer: RxB,
     ) -> Result<TransferSplit<T, TxB, RxB>, (Error, Spis<T>, TxB, RxB)>
     where
-        TxB: ReadBuffer<Word = TxW>,
-        RxB: WriteBuffer<Word = RxW>,
+        TxB: ReadBuffer<Word = TxW> + 'static,
+        RxB: WriteBuffer<Word = RxW> + 'static,
     {
         let (rx_ptr, rx_len) = unsafe { rx_buffer.write_buffer() };
         let (tx_ptr, tx_len) = unsafe { tx_buffer.read_buffer() };


### PR DESCRIPTION
We need + 'static on the `WriteBuffer`/`ReadBuffer` bounds