### PR TITLE
TWIM improvements.

### DIFF
--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -568,7 +568,7 @@ pub struct Pins {
     pub sda: Pin<Input<Floating>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Error {
     TxBufferTooLong,
     RxBufferTooLong,


### PR DESCRIPTION
- Derive Copy, Clone, Eq, PartialEq for Error
- Disallow zero-length buffers, fixes #208 
- Handle all errors. Previously only AddressNack was handled, and the transfer would hang if another error ocurred.
- remove chunking in `copy_write_then_read`.  The previous implementation would send a TWI start condition for each chunk, so the slave chip would see each as a separate transaction. This is not equivalent to `write_then_read`, which was the original goal of adding chunking. It seems TWIM has no way to send multiple buffers in a single transaction, therefore the ability to chunk is removed.


There are some issues left with TWIM:

- There's no way for the user use SUSPEND manually if they want to do a more complex repeated start sequence. Nordic's lib has a "hold" flag that suspends instead of stopping so you can do any combination of reads and writes. 

  If we do this it could be used for implementing `write_then_read` and  `copy_write_then_read` to reduce code duplication
  
  This is probably left for a future PR :) 

<details><summary>old, no longer apply</summary>
<p>
- `copy_write_then_read` splits written data into 1024 byte chunks and txs each individually. This actually causes a repeated start condition for each chunk, instead of a single start condition at the beginning like it would happen with `write_then_read`. 

  This should be at least documented, but I think in practice the chunking is useless because devices will take data after a repeated start as a new transaction (expecting you to send command/address bytes again).
  
  Maybe we should remove the chunking?

- `copy_write_then_read` should use SUSPEND. It seems that once LASTRX/LASTTX happens it's not OK to leave TWIM hanging, you must immediately STOP, SUSPEND, or STARTTX/STARTRX. This can be a problem if using TWIM from low priority code. Nordic says [here](https://infocenter.nordicsemi.com/topic/ps_nrf52840/twim.html?cp=4_0_0_5_30_3#concept_ebf_cwp_xr):

  > If a more complex repeated start sequence is needed and the TWI firmware drive is serviced in a low priority interrupt it may be necessary to use the SUSPEND task and SUSPENDED event to guarantee that the correct tasks are generated at the correct time. 

  This was a problem before with `write_then_read` too, but this PR changes it to use SHORTS.
</p></details>
