### PR TITLE
Make `ConfigurablePpi` a subtrait of `Ppi`

### DIFF
--- a/nrf-hal-common/src/ppi/mod.rs
+++ b/nrf-hal-common/src/ppi/mod.rs
@@ -82,7 +82,7 @@ pub trait Ppi {
 }
 
 /// Traits that extends the [Ppi](trait.Ppi.html) trait, marking a channel as fully configurable.
-pub trait ConfigurablePpi {
+pub trait ConfigurablePpi: Ppi {
     /// Sets the task that must be triggered when the configured event occurs. The user must provide
     /// a reference to the task.
     fn set_task_endpoint<T: Task>(&mut self, task: &T);


### PR DESCRIPTION
This allows to create nice generic driver APIs with `impl ConfigurablePpi` arguments
Example:
```` rust
fn link_pins(
    gpiote: &hal::gpiote::Gpiote,
    mut ppi: impl ConfigurablePpi,
    out_pin: Pin<Output<PushPull>>,
    in_pin: Pin<Input<PullUp>>,
) {
    // ...
}
`````