### PR TITLE
Also release owned `Pins` with `Usart::free()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improve SAADC docs ([#218]).
 - Update Embed.toml of all examples to new defaults ([#229]).
 - Make `ConfigurablePpi` and subtrait of `Ppi` ([#244]).
+- Release owned `Pins` with `Usart::free()` ([#261])
 
 ### Fixes
 

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -43,8 +43,8 @@ pub enum Port {
     Port1,
 }
 
+#[cfg(any(feature = "52833", feature = "52840"))]
 impl Port {
-    #[cfg(any(feature = "52833", feature = "52840"))]
     pub(crate) fn bit(&self) -> bool {
         match self {
             Port::Port0 => false,
@@ -52,7 +52,6 @@ impl Port {
         }
     }
 
-    #[cfg(any(feature = "52833", feature = "52840"))]
     pub(crate) fn from_bit(bit: bool) -> Port {
         if bit {
             Port::Port1

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -51,6 +51,15 @@ impl Port {
             Port::Port1 => true,
         }
     }
+
+    #[cfg(any(feature = "52833", feature = "52840"))]
+    pub(crate) fn from_bit(bit: bool) -> Port {
+        if bit {
+            Port::Port1
+        } else {
+            Port::Port0
+        }
+    }
 }
 
 // ===============================================================
@@ -81,7 +90,7 @@ use crate::hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
 use void::Void;
 
 impl<MODE> Pin<MODE> {
-    fn new(port: Port, pin: u8) -> Self {
+    pub(crate) fn new(port: Port, pin: u8) -> Self {
         let port_bits = match port {
             Port::Port0 => 0x00,
             #[cfg(any(feature = "52833", feature = "52840"))]


### PR DESCRIPTION
Return ownership of the pins back to the user when calling `free()`
Useful to multiplex a single USARTE instance to multiple serial connections on different pins (for smaller NRF52 devices which only have one USARTE instance).

Alternative: Only take a reference to the pins in in `new()`.
Please let me know which one is the preferred approach.