### PR TITLE
Enabling and disabling the TWIM instance

### DIFF
--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -86,14 +86,14 @@ where
         Twim(twim)
     }
 
-    /// Re-enable the instance after it was previously disabled.
-    pub fn enable(&mut self) {
-        self.0.enable.write(|w| w.enable().enabled());
-    }
-
     /// Disable the instance.
     pub fn disable(&mut self) {
         self.0.enable.write(|w| w.enable().disabled());
+    }
+
+    /// Re-enable the instance after it was previously disabled.
+    pub fn enable(&mut self) {
+        self.0.enable.write(|w| w.enable().enabled());
     }
 
     /// Set TX buffer, checking that it is in RAM and has suitable length.

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -86,10 +86,12 @@ where
         Twim(twim)
     }
 
+    /// Enable the instance.
     pub fn enable(&mut self) {
         self.0.enable.write(|w| w.enable().enabled());
     }
 
+    /// Disable the instance.
     pub fn disable(&mut self) {
         self.0.enable.write(|w| w.enable().disabled());
     }

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -86,7 +86,7 @@ where
         Twim(twim)
     }
 
-    /// Enable the instance.
+    /// Re-enable the instance after it was previously disabled.
     pub fn enable(&mut self) {
         self.0.enable.write(|w| w.enable().enabled());
     }

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -87,11 +87,11 @@ where
     }
 
     pub fn enable(&mut self) {
-        twim.enable.write(|w| w.enable().enabled());
+        self.0.enable.write(|w| w.enable().enabled());
     }
 
     pub fn disable(&mut self) {
-        twim.enable.write(|w| w.enable().disabled());
+        self.0.enable.write(|w| w.enable().disabled());
     }
 
     /// Set TX buffer, checking that it is in RAM and has suitable length.

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -86,6 +86,14 @@ where
         Twim(twim)
     }
 
+    pub fn enable(&mut self) {
+        twim.enable.write(|w| w.enable().enabled());
+    }
+
+    pub fn disable(&mut self) {
+        twim.enable.write(|w| w.enable().disabled());
+    }
+
     /// Set TX buffer, checking that it is in RAM and has suitable length.
     unsafe fn set_tx_buffer(&mut self, buffer: &[u8]) -> Result<(), Error> {
         slice_in_ram_or(buffer, Error::DMABufferNotInDataMemory)?;

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -87,6 +87,11 @@ where
     }
 
     /// Disable the instance.
+    /// 
+    /// Disabling the instance will switch off the peripheral leading to a
+    /// considerably lower energy use. However, while the instance is disabled
+    /// it is not possible to use it for communication. The configuration of
+    /// the instance will be retained.
     pub fn disable(&mut self) {
         self.0.enable.write(|w| w.enable().disabled());
     }


### PR DESCRIPTION
When a new TWIM instance is created, it is automatically enabled. This is very convenient in normal use. For a low power sensor, I found myself in the situation that I needed to deactivate (and later reactivate) the instance in order to safe energy. The simplest way I found to do this, was to add the "enable" and "disable" functions to the instance.

Please let me know, whether you would like to integrate this change into the main branch.