### PR TITLE
UART EasyDMA example

### DIFF
--- a/examples/uarte-demo/Cargo.toml
+++ b/examples/uarte-demo/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "uarte-demo"
+version = "0.1.0"
+authors = ["Jesse C. Laning"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
+rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]

--- a/examples/uarte-demo/Embed.toml
+++ b/examples/uarte-demo/Embed.toml
@@ -1,0 +1,63 @@
+[default.probe]
+# USB vendor ID
+# usb_vid = "1337"
+# USB product ID
+# usb_pid = "1337"
+# Serial number
+# serial = "12345678"
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[default.flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after reset.
+# DEPRECATED, moved to reset section
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[default.reset]
+# Whether or not the target should be reset.
+# When flashing is enabled as well, the target will be reset after flashing.
+enabled = true
+# Whether or not the target should be halted after reset.
+halt_afterwards = false
+
+[default.general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used. Possible values are one of:
+#   "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" 
+log_level = "WARN"
+
+[default.rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = true
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name", format = "String" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+# Whether to save rtt history buffer on exit.
+log_enabled = false
+# Where to save rtt history buffer relative to manifest path.
+log_path = "./logs"
+
+[default.gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/uarte-demo/README.md
+++ b/examples/uarte-demo/README.md
@@ -1,0 +1,26 @@
+# UART EasyDMA Demo
+
+This example echos commands, denoted by a new line, sent to the UARTE0 interface and over RTT (Real-Time Transfer) I/O protocol for debug purposes.
+
+This was designed for the nRF52840-DK (PCA10056):
+https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK
+
+## HW connections
+Pin     Connecton
+P0.06   TX
+P0.08   RX
+
+## Set up with `cargo-embed`
+
+Install `cargo-embed` if you don't have it already:
+
+```console
+$ cargo install cargo-embed
+```
+
+Then just `cd` to the example folder and run
+
+```console
+$ cargo embed --target thumbv7em-none-eabihf
+```
+

--- a/examples/uarte-demo/src/main.rs
+++ b/examples/uarte-demo/src/main.rs
@@ -1,0 +1,87 @@
+#![no_std]
+#![no_main]
+
+use {
+    core::{
+        str,
+        fmt::Write,
+        panic::PanicInfo,
+        sync::atomic::{compiler_fence, Ordering},
+    },
+    cortex_m_rt::entry,
+    hal::gpio::Level,
+    nrf52840_hal as hal,
+    rtt_target::{rprintln, rtt_init_print},
+};
+
+#[inline(never)]
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    cortex_m::interrupt::disable();
+    loop {
+        compiler_fence(Ordering::SeqCst);
+    }
+}
+
+#[entry]
+fn main() -> ! {
+    rtt_init_print!();
+    let peripherals = hal::pac::Peripherals::take().unwrap();
+    hal::clocks::Clocks::new(peripherals.CLOCK).enable_ext_hfosc();
+
+    let p0 = hal::gpio::p0::Parts::new(peripherals.P0);
+
+    // configure UARTE0
+    let uarte0 = peripherals.UARTE0;
+    let txd = p0.p0_06.into_push_pull_output(Level::Low).degrade();
+    let rxd = p0.p0_08.into_floating_input().degrade();
+
+    let pins = hal::uarte::Pins {
+        rxd,
+        txd,
+        cts: None,
+        rts: None,
+    };
+
+    let mut serial = hal::uarte::Uarte::new(
+        uarte0,
+        pins,
+        hal::uarte::Parity::EXCLUDED,
+        hal::uarte::Baudrate::BAUD115200,
+    );
+
+    // duplicating messages over rtt to compare results
+    writeln!(serial, "Hello, World!").unwrap();
+    rprintln!("Hello, World!");
+
+    let mut rx_buffer = [0u8];
+    let mut buf = [0u8; 255];
+    let mut index = 0;
+
+    // basic serial echoing
+    loop {
+        // read one byte
+        serial.read(&mut rx_buffer).unwrap();
+        // transfer byte to our buffer
+        buf[index] = rx_buffer[0];
+        index += 1;
+
+        // check if we've filled our buffer or a new line byte was sent
+        if index == buf.len() || rx_buffer[0] == '\n' as u8 {
+            // write buffer back
+            serial.write(&buf).unwrap();
+
+            // strip the new line since rprintln automatically adds one
+            if rx_buffer[0] == '\n' as u8 {
+                buf[index - 1] = 0;
+            }
+            // duplicating messages over rtt to compare results
+            rprintln!("{}", str::from_utf8(&buf).unwrap());
+
+            // reset the buffer so we don't have stale data
+            buf.iter_mut().for_each(|m| *m = 0);
+
+            index = 0;
+        }
+    }
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -36,6 +36,7 @@ pub static EXAMPLES: &[(&str, &[&str])] = &[
     ("twim-demo", &[]),
     ("twis-demo", &[]),
     ("twis-dma-demo", &[]),
+    ("uarte-demo", &[]),
     ("wdt-demo", &[]),
 ];
 


### PR DESCRIPTION
This example echos commands, denoted by a new line, sent to the UARTE0 interface and over RTT (Real-Time Transfer) I/O protocol for debug purposes. I saw there were a few other pull requests with UART examples but they were more complicated, this gives a starting point which is severely under-documented.

This was designed and tested on the nRF52840-DK (PCA10056):
https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK

but I'm sure it can be easily expanded