### PR TITLE
Make GPIO `Port` methods public

### DIFF
--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -45,14 +45,14 @@ pub enum Port {
 
 #[cfg(any(feature = "52833", feature = "52840"))]
 impl Port {
-    pub(crate) fn bit(&self) -> bool {
+    pub fn bit(&self) -> bool {
         match self {
             Port::Port0 => false,
             Port::Port1 => true,
         }
     }
 
-    pub(crate) fn from_bit(bit: bool) -> Port {
+    pub fn from_bit(bit: bool) -> Port {
         if bit {
             Port::Port1
         } else {


### PR DESCRIPTION
This change allows external code to assign pins to peripherals.
Prevents hotfixes like: https://github.com/akiles/embassy/blob/267ec334ac766097efb4c847c14b6e2fde44f9af/embassy-nrf/src/buffered_uarte.rs#L158-L164