### PR TITLE
Adding WDT to nRF9160.

### DIFF
--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -78,7 +78,6 @@ pub mod uart;
 pub mod uarte;
 #[cfg(not(feature = "9160"))]
 pub mod uicr;
-#[cfg(not(feature = "9160"))]
 pub mod wdt;
 
 pub mod prelude {

--- a/nrf-hal-common/src/wdt.rs
+++ b/nrf-hal-common/src/wdt.rs
@@ -8,8 +8,7 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "9160")]{
         use crate::pac::WDT_NS as WDT;
-    }
-    else {
+    } else {
         use crate::pac::WDT;
     }
 }

--- a/nrf-hal-common/src/wdt.rs
+++ b/nrf-hal-common/src/wdt.rs
@@ -214,8 +214,7 @@ where
     #[inline(always)]
     pub fn is_active(&self) -> bool {
         cfg_if! {
-            if #[cfg(feature = "9160")]
-            {
+            if #[cfg(feature = "9160")] {
                 self.wdt.runstatus.read().runstatuswdt().bit_is_set()
             } else {
                 self.wdt.runstatus.read().runstatus().bit_is_set()

--- a/nrf-hal-common/src/wdt.rs
+++ b/nrf-hal-common/src/wdt.rs
@@ -6,7 +6,7 @@
 use cfg_if::cfg_if;
 
 cfg_if! {
-    if #[cfg(feature = "9160")]{
+    if #[cfg(feature = "9160")] {
         use crate::pac::WDT_NS as WDT;
     } else {
         use crate::pac::WDT;

--- a/nrf-hal-common/src/wdt.rs
+++ b/nrf-hal-common/src/wdt.rs
@@ -3,7 +3,18 @@
 //! This HAL implements a basic watchdog timer with 1..=8 handles.
 //! Once the watchdog has been started, it cannot be stopped.
 
-use crate::pac::WDT;
+use cfg_if::cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "9160")]{
+        use crate::pac::WDT_NS as WDT;
+    }
+    else {
+        use crate::pac::WDT;
+    }
+}
+
+
 use handles::*;
 
 /// A type state representing a watchdog that has not been started.
@@ -202,7 +213,14 @@ where
     /// Is the watchdog active?
     #[inline(always)]
     pub fn is_active(&self) -> bool {
-        self.wdt.runstatus.read().runstatus().bit_is_set()
+        cfg_if! {
+            if #[cfg(feature = "9160")]
+            {
+                self.wdt.runstatus.read().runstatuswdt().bit_is_set()
+            } else {
+                self.wdt.runstatus.read().runstatus().bit_is_set()
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Small changes to make WDT work on the nRF9160.

Tested on my hardware (Actinius Icarus):
* set_lfosc_ticks
* activate
* try_recover
* pet


