### PR TITLE
Refactor Pin Selection and Reconstructions

### DIFF
--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -43,41 +43,31 @@ impl I2S {
 
         if let Some(p) = mck_pin {
             i2s.psel.mck.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
 
         i2s.psel.sck.write(|w| {
-            unsafe { w.pin().bits(sck_pin.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(sck_pin.port().bit());
+            unsafe { w.bits(sck_pin.psel_bits()) };
             w.connect().connected()
         });
 
         i2s.psel.lrck.write(|w| {
-            unsafe { w.pin().bits(lrck_pin.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(lrck_pin.port().bit());
+            unsafe { w.bits(lrck_pin.psel_bits()) };
             w.connect().connected()
         });
 
         if let Some(p) = sdin_pin {
             i2s.psel.sdin.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
 
         if let Some(p) = sdout_pin {
             i2s.psel.sdout.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
@@ -105,41 +95,31 @@ impl I2S {
 
         if let Some(p) = mck_pin {
             i2s.psel.mck.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
 
         i2s.psel.sck.write(|w| {
-            unsafe { w.pin().bits(sck_pin.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(sck_pin.port().bit());
+            unsafe { w.bits(sck_pin.psel_bits()) };
             w.connect().connected()
         });
 
         i2s.psel.lrck.write(|w| {
-            unsafe { w.pin().bits(lrck_pin.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(lrck_pin.port().bit());
+            unsafe { w.bits(lrck_pin.psel_bits()) };
             w.connect().connected()
         });
 
         if let Some(p) = sdin_pin {
             i2s.psel.sdin.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
 
         if let Some(p) = sdout_pin {
             i2s.psel.sdout.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -4,7 +4,6 @@
 
 #[cfg(not(any(feature = "52810", feature = "52811")))]
 use crate::{
-    gpio::Port,
     pac::PWM3,
     pac::{PWM1, PWM2},
 };
@@ -133,14 +132,7 @@ where
     #[inline(always)]
     pub fn set_output_pin(&self, channel: Channel, pin: &Pin<Output<PushPull>>) -> &Self {
         self.pwm.psel.out[usize::from(channel)].write(|w| {
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            match pin.port() {
-                Port::Port0 => w.port().clear_bit(),
-                Port::Port1 => w.port().set_bit(),
-            };
-            unsafe {
-                w.pin().bits(pin.pin());
-            }
+            unsafe { w.bits(pin.psel_bits()) };
             w.connect().connected()
         });
         self

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -3,8 +3,6 @@
 //! The Quadrature decoder (QDEC) provides buffered decoding of quadrature-encoded sensor signals.
 //! It is suitable for mechanical and optical sensors.
 
-#[cfg(any(feature = "52833", feature = "52840"))]
-use crate::gpio::Port;
 use {
     crate::gpio::{Input, Pin, PullUp},
     crate::pac::QDEC,
@@ -28,32 +26,18 @@ impl Qdec {
         sample_period: SamplePeriod,
     ) -> Self {
         qdec.psel.a.write(|w| {
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            match pin_a.port() {
-                Port::Port0 => w.port().clear_bit(),
-                Port::Port1 => w.port().set_bit(),
-            };
-            unsafe { w.pin().bits(pin_a.pin()) };
+            unsafe { w.bits(pin_a.psel_bits()) };
             w.connect().connected()
         });
         qdec.psel.b.write(|w| {
             #[cfg(any(feature = "52833", feature = "52840"))]
-            match pin_b.port() {
-                Port::Port0 => w.port().clear_bit(),
-                Port::Port1 => w.port().set_bit(),
-            };
-            unsafe { w.pin().bits(pin_b.pin()) };
+            unsafe { w.bits(pin_b.psel_bits()) };
             w.connect().connected()
         });
 
         if let Some(p) = &pin_led {
             qdec.psel.led.write(|w| {
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                match p.port() {
-                    Port::Port0 => w.port().clear_bit(),
-                    Port::Port1 => w.port().set_bit(),
-                };
-                unsafe { w.pin().bits(p.pin()) };
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -30,7 +30,6 @@ impl Qdec {
             w.connect().connected()
         });
         qdec.psel.b.write(|w| {
-            #[cfg(any(feature = "52833", feature = "52840"))]
             unsafe { w.bits(pin_b.psel_bits()) };
             w.connect().connected()
         });

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -100,26 +100,20 @@ where
     pub fn new(spim: T, pins: Pins, frequency: Frequency, mode: Mode, orc: u8) -> Self {
         // Select pins.
         spim.psel.sck.write(|w| {
-            let w = unsafe { w.pin().bits(pins.sck.pin()) };
-            #[cfg(any(feature = "52843", feature = "52840"))]
-            let w = w.port().bit(pins.sck.port().bit());
+            unsafe { w.bits(pins.sck.psel_bits()) };
             w.connect().connected()
         });
 
         match pins.mosi {
             Some(mosi) => spim.psel.mosi.write(|w| {
-                let w = unsafe { w.pin().bits(mosi.pin()) };
-                #[cfg(any(feature = "52843", feature = "52840"))]
-                let w = w.port().bit(mosi.port().bit());
+                unsafe { w.bits(mosi.psel_bits()) };
                 w.connect().connected()
             }),
             None => spim.psel.mosi.write(|w| w.connect().disconnected()),
         }
         match pins.miso {
             Some(miso) => spim.psel.miso.write(|w| {
-                let w = unsafe { w.pin().bits(miso.pin()) };
-                #[cfg(any(feature = "52843", feature = "52840"))]
-                let w = w.port().bit(miso.port().bit());
+                unsafe { w.bits(miso.psel_bits()) };
                 w.connect().connected()
             }),
             None => spim.psel.miso.write(|w| w.connect().disconnected()),

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -48,32 +48,24 @@ where
     /// returning a safe wrapper.
     pub fn new(spis: T, pins: Pins) -> Self {
         spis.psel.sck.write(|w| {
-            unsafe { w.pin().bits(pins.sck.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(pins.sck.port().bit());
+            unsafe { w.bits(pins.sck.psel_bits()) };
             w.connect().connected()
         });
         spis.psel.csn.write(|w| {
-            unsafe { w.pin().bits(pins.cs.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            w.port().bit(pins.cs.port().bit());
+            unsafe { w.bits(pins.cs.psel_bits()) };
             w.connect().connected()
         });
 
         if let Some(p) = &pins.copi {
             spis.psel.mosi.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }
 
         if let Some(p) = &pins.cipo {
             spis.psel.miso.write(|w| {
-                unsafe { w.pin().bits(p.pin()) };
-                #[cfg(any(feature = "52833", feature = "52840"))]
-                w.port().bit(p.port().bit());
+                unsafe { w.bits(p.psel_bits()) };
                 w.connect().connected()
             });
         }

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -67,15 +67,11 @@ where
 
         // Select pins.
         twim.psel.scl.write(|w| {
-            let w = unsafe { w.pin().bits(pins.scl.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.scl.port().bit());
+            unsafe { w.bits(pins.scl.psel_bits()) };
             w.connect().connected()
         });
         twim.psel.sda.write(|w| {
-            let w = unsafe { w.pin().bits(pins.sda.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.sda.port().bit());
+            unsafe { w.bits(pins.sda.psel_bits()) };
             w.connect().connected()
         });
 

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -60,15 +60,11 @@ where
         }
 
         twis.psel.scl.write(|w| {
-            let w = unsafe { w.pin().bits(pins.scl.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.scl.port().bit());
+            unsafe { w.bits(pins.scl.psel_bits()) };
             w.connect().connected()
         });
         twis.psel.sda.write(|w| {
-            let w = unsafe { w.pin().bits(pins.sda.pin()) };
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            let w = w.port().bit(pins.sda.port().bit());
+            unsafe { w.bits(pins.sda.psel_bits()) };
             w.connect().connected()
         });
 


### PR DESCRIPTION
Moves the scattered `#[cfg()]` to a single place in the gpio module.