### PR TITLE
saadc: Clear events_calibratedone before calibration

### DIFF
--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -87,6 +87,7 @@ impl Saadc {
         saadc.ch[0].pseln.write(|w| w.pseln().nc());
 
         // Calibrate
+        saadc.events_calibratedone.reset();
         saadc.tasks_calibrateoffset.write(|w| unsafe { w.bits(1) });
         while saadc.events_calibratedone.read().bits() == 0 {}
 


### PR DESCRIPTION
Without this, if you initialize SAADC for a second time, the events_calibratedone is still set from before, so the while loop doesn't wait for calibration to be done. This causes garbage readings if you read immediately after, because calibration is still running.