### PR TITLE
Fix PWM EasyDMA max length

### DIFF
--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -20,6 +20,8 @@ use core::{
 };
 use embedded_dma::*;
 
+const MAX_SEQ_LEN: usize = 0x7FFF;
+
 /// A safe wrapper around the raw peripheral.
 #[derive(Debug)]
 pub struct Pwm<T: Instance> {
@@ -507,7 +509,7 @@ where
                     seq1_buffer,
                 ));
             }
-            if len > (1 << 15) / core::mem::size_of::<u16>() {
+            if len > MAX_SEQ_LEN {
                 return Err((Error::BufferTooLong, self, seq0_buffer, seq1_buffer));
             }
             compiler_fence(Ordering::SeqCst);
@@ -530,7 +532,7 @@ where
                     seq1_buffer,
                 ));
             }
-            if len > (1 << 15) / core::mem::size_of::<u16>() {
+            if len > MAX_SEQ_LEN {
                 return Err((Error::BufferTooLong, self, seq0_buffer, seq1_buffer));
             }
             compiler_fence(Ordering::SeqCst);


### PR DESCRIPTION
1. The max length is 0x7FFF, not 0x8000 (1<<15). The latter already doesn't fit in 15 bits.
2. The max length is in duty value count, not in bytes, so there's no need to divide by sizeof(u16)

I have verified the max length is 15 bits on all chips.