### PR TITLE
Uart example

### DIFF
--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "hello-world"
+version = "0.1.0"
+authors = ["Christopher Hunt"]
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cortex-m = "0.6.2"
+cortex-m-rt = "0.6.12"
+
+[dependencies.embedded-hal]
+version = "0.2.3"
+features = ["unproven"]
+
+[dependencies.nrf9160-hal]
+features = ["rt"]
+path = "../../nrf9160-hal"
+optional = true
+
+[dependencies.nrf52840-hal]
+features = ["rt"]
+path = "../../nrf52840-hal"
+optional = true
+
+[features]
+9160 = ["nrf9160-hal"]
+52840 = ["nrf52840-hal"]

--- a/examples/hello-world/Embed.toml
+++ b/examples/hello-world/Embed.toml
@@ -1,0 +1,63 @@
+[default.probe]
+# USB vendor ID
+# usb_vid = "1337"
+# USB product ID
+# usb_pid = "1337"
+# Serial number
+# serial = "12345678"
+# The protocol to be used for communicating with the target.
+protocol = "Swd"
+# The speed in kHz of the data link to the target.
+# speed = 1337
+
+[default.flashing]
+# Whether or not the target should be flashed.
+enabled = true
+# Whether or not the target should be halted after reset.
+# DEPRECATED, moved to reset section
+halt_afterwards = false
+# Whether or not bytes erased but not rewritten with data from the ELF
+# should be restored with their contents before erasing.
+restore_unwritten_bytes = false
+# The path where an SVG of the assembled flash layout should be written to.
+# flash_layout_output_path = "out.svg"
+
+[default.reset]
+# Whether or not the target should be reset.
+# When flashing is enabled as well, the target will be reset after flashing.
+enabled = true
+# Whether or not the target should be halted after reset.
+halt_afterwards = false
+
+[default.general]
+# The chip name of the chip to be debugged.
+chip = "nRF52840_xxAA"
+# A list of chip descriptions to be loaded during runtime.
+chip_descriptions = []
+# The default log level to be used. Possible values are one of:
+#   "OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" 
+log_level = "WARN"
+
+[default.rtt]
+# Whether or not an RTTUI should be opened after flashing.
+# This is exclusive and cannot be used with GDB at the moment.
+enabled = false
+# A list of channel associations to be displayed. If left empty, all channels are displayed.
+channels = [
+    # { up = 0, down = 0, name = "name", format = "String" }
+]
+# The duration in ms for which the logger should retry to attach to RTT.
+timeout = 3000
+# Whether timestamps in the RTTUI are enabled
+show_timestamps = true
+# Whether to save rtt history buffer on exit.
+log_enabled = false
+# Where to save rtt history buffer relative to manifest path.
+log_path = "./logs"
+
+[default.gdb]
+# Whether or not a GDB server should be opened after flashing.
+# This is exclusive and cannot be used with RTT at the moment.
+enabled = false
+# The connection string in host:port format wher the GDB server will open a socket.
+# gdb_connection_string

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -1,0 +1,64 @@
+#![no_std]
+#![no_main]
+
+// Simple UART example
+
+#[cfg(feature = "52840")]
+use nrf52840_hal as hal;
+#[cfg(feature = "9160")]
+use nrf9160_hal as hal;
+
+use core::fmt::Write;
+use hal::{gpio, uarte, uarte::Uarte};
+
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let p = hal::pac::Peripherals::take().unwrap();
+
+    #[cfg(feature = "52840")]
+    let (uart0, cdc_pins) = {
+        let p0 = gpio::p0::Parts::new(p.P0);
+        (
+            p.UARTE0,
+            uarte::Pins {
+                txd: p0.p0_06.into_push_pull_output(gpio::Level::High).degrade(),
+                rxd: p0.p0_08.into_floating_input().degrade(),
+                cts: Some(p0.p0_07.into_floating_input().degrade()),
+                rts: Some(p0.p0_05.into_push_pull_output(gpio::Level::High).degrade()),
+            },
+        )
+    };
+    #[cfg(feature = "9160")]
+    let (uart0, cdc_pins) = {
+        let p0 = gpio::p0::Parts::new(p.P0_NS);
+        (
+            p.UARTE0_NS,
+            uarte::Pins {
+                txd: p0.p0_29.into_push_pull_output(gpio::Level::High).degrade(),
+                rxd: p0.p0_28.into_floating_input().degrade(),
+                cts: Some(p0.p0_26.into_floating_input().degrade()),
+                rts: Some(p0.p0_27.into_push_pull_output(gpio::Level::High).degrade()),
+            },
+        )
+    };
+
+    let mut uarte = Uarte::new(
+        uart0,
+        cdc_pins,
+        uarte::Parity::EXCLUDED,
+        uarte::Baudrate::BAUD115200,
+    );
+
+    write!(uarte, "Hello, World!\r\n").unwrap();
+
+    loop {
+        cortex_m::asm::wfi();
+    }
+}
+
+#[panic_handler] // panicking behavior
+fn panic(_: &core::panic::PanicInfo) -> ! {
+    loop {
+        cortex_m::asm::bkpt();
+    }
+}

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -18,6 +18,7 @@ pub static EXAMPLES: &[(&str, &[&str])] = &[
         "ecb-demo",
         &["51", "52810", "52811", "52832", "52833", "52840"],
     ),
+    ("hello-world", &["52840"]),
     ("gpiote-demo", &[]),
     ("i2s-controller-demo", &[]),
     ("i2s-peripheral-demo", &[]),

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -18,7 +18,7 @@ pub static EXAMPLES: &[(&str, &[&str])] = &[
         "ecb-demo",
         &["51", "52810", "52811", "52832", "52833", "52840"],
     ),
-    ("hello-world", &["52840"]),
+    ("hello-world", &["52840", "9160"]),
     ("gpiote-demo", &[]),
     ("i2s-controller-demo", &[]),
     ("i2s-peripheral-demo", &[]),
@@ -45,6 +45,7 @@ pub fn feature_to_target(feat: &str) -> &str {
     match feat {
         "51" => "thumbv6m-none-eabi",
         "52810" | "52811" => "thumbv7em-none-eabi",
+        "9160" => "thumbv8m.main-none-eabihf",
         _ if feat.starts_with("52") => "thumbv7em-none-eabihf",
         _ => panic!("unknown Cargo feature `{}`", feat),
     }


### PR DESCRIPTION
Provides the simplest example of using UART for both the 52840 and 9160.

Tested successfully on:

* nrf52840-dk
* nrf9160-dk
* Thingy:91 (having modified the GPIO pins locally)