### PR TITLE
Enable PWM for nrf52832

### DIFF
--- a/examples/pwm-blinky-demo/Cargo.toml
+++ b/examples/pwm-blinky-demo/Cargo.toml
@@ -21,6 +21,11 @@ features = ["rt"]
 path = "../../nrf9160-hal"
 optional = true
 
+[dependencies.nrf52832-hal]
+features = ["rt"]
+path = "../../nrf52832-hal"
+optional = true
+
 [dependencies.nrf52840-hal]
 features = ["rt"]
 path = "../../nrf52840-hal"
@@ -29,3 +34,4 @@ optional = true
 [features]
 9160 = ["nrf9160-hal"]
 52840 = ["nrf52840-hal"]
+52832 = ["nrf52832-hal"]

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -49,7 +49,7 @@ pub mod ieee802154;
 pub mod lpcomp;
 #[cfg(not(feature = "9160"))]
 pub mod ppi;
-#[cfg(not(any(feature = "51", feature = "52832")))]
+#[cfg(not(feature = "51"))]
 pub mod pwm;
 #[cfg(not(any(feature = "51", feature = "9160")))]
 pub mod qdec;


### PR DESCRIPTION
It compiles cleanly, except for the PAC missing fields for the tasks registers. Replaced those with `.bits(1)`, which works on all chips.

Untested on hardware as I don't have a nrf52832 at hand.