### PR TITLE
Fix TWIS is_done() always returns true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-(no changes)
+### Fixes
+
+- Fix TWIS transfer `is_done()` always returns true ([#329]).
+
+[#329]: https://github.com/nrf-rs/nrf-hal/pull/329
 
 ## [0.12.2]
 
@@ -126,9 +130,9 @@
 - Also return owned `Pins` from `Usart::free()` ([#261]).
 
 ¹ _A trait can be sealed by making a private trait a supertrait. That way, no
-  downstream crates can implement it (since they can't name the supertrait).
-  This is just to make sure the trait isn't implemented by types that shouldn't
-  implement it._
+downstream crates can implement it (since they can't name the supertrait).
+This is just to make sure the trait isn't implemented by types that shouldn't
+implement it._
 
 ### Internal Improvements
 

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -518,8 +518,7 @@ impl<T: Instance, B> Transfer<T, B> {
             .inner
             .as_mut()
             .unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
-        inner.twis.is_done();
-        true
+        inner.twis.is_done()
     }
 }
 


### PR DESCRIPTION
Noticed there was a mistake in the `Transfer`  `is_done()` of the TWIS module, it always returns true.