### PR TITLE
Fix SPIS Transfer is_done() mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Fixes
 
-- Fix mistake in SPIS `Transfer` `is_done` to borrow `inner`.
+- Fix mistake in SPIS `Transfer` `is_done` to borrow `inner` ([#330]).
+
+[#330]: https://github.com/nrf-rs/nrf-hal/pull/330
 
 ## [0.12.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-(no changes)
+### Fixes
+
+- Fix mistake in SPIS `Transfer` `is_done` to borrow `inner`.
 
 ## [0.12.2]
 
@@ -126,9 +128,9 @@
 - Also return owned `Pins` from `Usart::free()` ([#261]).
 
 ¹ _A trait can be sealed by making a private trait a supertrait. That way, no
-  downstream crates can implement it (since they can't name the supertrait).
-  This is just to make sure the trait isn't implemented by types that shouldn't
-  implement it._
+downstream crates can implement it (since they can't name the supertrait).
+This is just to make sure the trait isn't implemented by types that shouldn't
+implement it._
 
 ### Internal Improvements
 

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -439,7 +439,7 @@ impl<T: Instance, B> Transfer<T, B> {
     pub fn is_done(&mut self) -> bool {
         let inner = self
             .inner
-            .take()
+            .as_mut()
             .unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
         inner.spis.is_done()
     }


### PR DESCRIPTION
Noticed there was a mistake in the `Transfer` impl of `is_done()` where it would `take()` `inner` instead of `as_mut()`.