### PR TITLE
Fix `Pwm::set_output_pin` soundness, add `swap_output_pin`

### DIFF
--- a/examples/pwm-blinky-demo/src/main.rs
+++ b/examples/pwm-blinky-demo/src/main.rs
@@ -3,10 +3,10 @@
 
 use hal::{gpio, prelude::*, pwm, pwm::Pwm, timer, timer::Timer};
 use nb::block;
-#[cfg(feature = "52840")]
-use nrf52840_hal as hal;
 #[cfg(feature = "52832")]
 use nrf52832_hal as hal;
+#[cfg(feature = "52840")]
+use nrf52840_hal as hal;
 #[cfg(feature = "9160")]
 use nrf9160_hal as hal;
 use rtt_target::{rprintln, rtt_init_print};
@@ -29,7 +29,7 @@ fn main() -> ! {
     pwm.set_period(500u32.hz());
 
     rprintln!("PWM Blinky demo starting");
-    
+
     let wait_time = 1_000_000u32 / pwm.get_max_duty() as u32;
     loop {
         for duty in 0..pwm.get_max_duty() {
@@ -46,7 +46,7 @@ fn init_device(p: hal::pac::Peripherals) -> (Pwm<hal::pac::PWM0_NS>, Timer<hal::
     let pwm = Pwm::new(p.PWM0_NS);
     pwm.set_output_pin(
         pwm::Channel::C0,
-        &p0.p0_02.into_push_pull_output(gpio::Level::High).degrade(),
+        p0.p0_02.into_push_pull_output(gpio::Level::High).degrade(),
     );
 
     let timer = Timer::new(p.TIMER0_NS);
@@ -61,7 +61,7 @@ fn init_device(p: hal::pac::Peripherals) -> (Pwm<hal::pac::PWM0>, Timer<hal::pac
     let pwm = Pwm::new(p.PWM0);
     pwm.set_output_pin(
         pwm::Channel::C0,
-        &p0.p0_13.into_push_pull_output(gpio::Level::High).degrade(),
+        p0.p0_13.into_push_pull_output(gpio::Level::High).degrade(),
     );
 
     let timer = Timer::new(p.TIMER0);
@@ -76,14 +76,13 @@ fn init_device(p: hal::pac::Peripherals) -> (Pwm<hal::pac::PWM0>, Timer<hal::pac
     let pwm = Pwm::new(p.PWM0);
     pwm.set_output_pin(
         pwm::Channel::C0,
-        &p0.p0_30.into_push_pull_output(gpio::Level::High).degrade(),
+        p0.p0_30.into_push_pull_output(gpio::Level::High).degrade(),
     );
 
     let timer = Timer::new(p.TIMER0);
 
     (pwm, timer)
 }
-
 
 fn delay<T>(timer: &mut Timer<T>, cycles: u32)
 where

--- a/examples/pwm-demo/src/main.rs
+++ b/examples/pwm-demo/src/main.rs
@@ -69,10 +69,10 @@ const APP: () = {
 
         let pwm = Pwm::new(ctx.device.PWM0);
         pwm.set_period(500u32.hz())
-            .set_output_pin(Channel::C0, &led1)
-            .set_output_pin(Channel::C1, &led2)
-            .set_output_pin(Channel::C2, &led3)
-            .set_output_pin(Channel::C3, &led4)
+            .set_output_pin(Channel::C0, led1)
+            .set_output_pin(Channel::C1, led2)
+            .set_output_pin(Channel::C2, led3)
+            .set_output_pin(Channel::C3, led4)
             .enable_interrupt(PwmEvent::Stopped)
             .enable();
 

--- a/examples/pwm-demo/src/main.rs
+++ b/examples/pwm-demo/src/main.rs
@@ -67,14 +67,20 @@ const APP: () = {
         let led3 = p0.p0_15.into_push_pull_output(Level::High).degrade();
         let led4 = p0.p0_16.into_push_pull_output(Level::High).degrade();
 
-        let pwm = Pwm::new(ctx.device.PWM0);
+        let mut pwm = Pwm::new(ctx.device.PWM0);
         pwm.set_period(500u32.hz())
             .set_output_pin(Channel::C0, led1)
             .set_output_pin(Channel::C1, led2)
             .set_output_pin(Channel::C2, led3)
             .set_output_pin(Channel::C3, led4)
-            .enable_interrupt(PwmEvent::Stopped)
-            .enable();
+            .enable_interrupt(PwmEvent::Stopped);
+
+        // In addition to `set_output_pin`, `swap_output_pin` and `clear_output_pin` can be used to
+        // get the old pin back.
+        let led1 = pwm.clear_output_pin(Channel::C0).unwrap();
+        assert!(pwm.swap_output_pin(Channel::C0, led1).is_none());
+
+        pwm.enable();
 
         let gpiote = Gpiote::new(ctx.device.GPIOTE);
         gpiote.port().input_pin(&btn1).low();

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -50,7 +50,9 @@ pub enum Port {
 // ===============================================================
 /// Generic $PX pin
 pub struct Pin<MODE> {
-    // Bit 7: Port, Bits 0-6: Pin
+    /// 00AB BBBB
+    /// A: Port
+    /// B: Pin
     pin_port: u8,
     _mode: PhantomData<MODE>,
 }


### PR DESCRIPTION
Fixes https://github.com/nrf-rs/nrf-hal/issues/320 by taking the pin by-value (cc @Dirbaio)

To allow the same flexibility as before, this adds `swap_output_pin`, which returns the old pin (though I haven't tested this API).