### PR TITLE
Implement `InputPin` regardless of mode

### DIFF
--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -259,7 +259,7 @@ impl<MODE> Pin<MODE> {
     }
 }
 
-impl<MODE> InputPin for Pin<Input<MODE>> {
+impl<MODE> InputPin for Pin<MODE> {
     type Error = Void;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -529,7 +529,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> InputPin for $PXi<Input<MODE>> {
+                impl<MODE> InputPin for $PXi<MODE> {
                     type Error = Void;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {


### PR DESCRIPTION
This should resolve https://github.com/nrf-rs/nrf-hal/issues/339

I *think* this is fine, since you can always read any pin regardless of configuration (even for disconnected pins, their value will just be floating).