### PR TITLE
VS Code: don't enable all features

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
     "rust-analyzer.checkOnSave.allTargets": false,
+    "rust-analyzer.cargo.allFeatures": false,
 }


### PR DESCRIPTION
Followup to https://github.com/nrf-rs/nrf-hal/pull/338, this makes things work even when `rust-analyzer.cargo.allFeatures` is globally enabled.

bors r+