### PR TITLE
common/spi: add support for all nRF52 devices

### DIFF
--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -60,7 +60,7 @@ pub mod rng;
 pub mod rtc;
 #[cfg(not(feature = "51"))]
 pub mod saadc;
-#[cfg(feature = "51")]
+#[cfg(not(feature = "9160"))]
 pub mod spi;
 #[cfg(not(feature = "51"))]
 pub mod spim;


### PR DESCRIPTION
This extends the `spi` implementation to all nRF52 devices.
Some features-based conditionals are required as those devices
have some slightly different register names and a varying amount
of supported interfaces.
Manually tested locally on a nRF52840 only.