### PR TITLE
UARTE: make number of stop bits configurable.

### DIFF
--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -47,6 +47,7 @@ fn main() -> ! {
         cdc_pins,
         uarte::Parity::EXCLUDED,
         uarte::Baudrate::BAUD115200,
+        uarte::Stopbits::ONE
     );
 
     write!(uarte, "Hello, World!\r\n").unwrap();

--- a/examples/i2s-controller-demo/src/main.rs
+++ b/examples/i2s-controller-demo/src/main.rs
@@ -108,6 +108,7 @@ const APP: () = {
             },
             Parity::EXCLUDED,
             Baudrate::BAUD115200,
+            Stopbits::ONE
         );
 
         *ctx.resources.queue = Some(Queue::new());

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -28,7 +28,7 @@ use crate::target_constants::EASY_DMA_SIZE;
 use crate::timer::{self, Timer};
 
 // Re-export SVD variants to allow user to directly set values.
-pub use uarte0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity};
+pub use uarte0::{baudrate::BAUDRATE_A as Baudrate, config::PARITY_A as Parity, config::STOP_A as Stopbits};
 
 /// Interface to a UARTE instance.
 ///
@@ -44,7 +44,7 @@ impl<T> Uarte<T>
 where
     T: Instance,
 {
-    pub fn new(uarte: T, mut pins: Pins, parity: Parity, baudrate: Baudrate) -> Self {
+    pub fn new(uarte: T, mut pins: Pins, parity: Parity, baudrate: Baudrate, stopbits: Stopbits) -> Self {
         // Is the UART already on? It might be if you had a bootloader
         if uarte.enable.read().bits() != 0 {
             uarte.tasks_stoptx.write(|w| unsafe { w.bits(1) });
@@ -90,7 +90,9 @@ where
         let hardware_flow_control = pins.rts.is_some() && pins.cts.is_some();
         uarte
             .config
-            .write(|w| w.hwfc().bit(hardware_flow_control).parity().variant(parity));
+            .write(|w| w.hwfc().bit(hardware_flow_control)
+			.parity().variant(parity)
+			.stop().variant(stopbits));
 
         // Configure frequency.
         uarte.baudrate.write(|w| w.baudrate().variant(baudrate));

--- a/nrf52840-hal-tests/tests/serial.rs
+++ b/nrf52840-hal-tests/tests/serial.rs
@@ -29,7 +29,7 @@ mod tests {
         pac,
     };
     use nrf52840_hal::{
-        uarte::{Baudrate, Parity, Pins, Uarte},
+        uarte::{Baudrate, Parity, Pins, Stopbits, Uarte},
         Timer,
     };
 
@@ -52,7 +52,7 @@ mod tests {
             rts: None,
         };
 
-        let _uarte = Uarte::new(p.UARTE0, pins, Parity::EXCLUDED, Baudrate::BAUD9600);
+        let _uarte = Uarte::new(p.UARTE0, pins, Parity::EXCLUDED, Baudrate::BAUD9600, Stopbits::ONE);
 
         State {
             _uarte,


### PR DESCRIPTION
This adds the "stopbits" parameter to the Uarte::new() constructor alongside the existing "parity" and "baudrate" parameters, giving users control over the last missing option provided by UARTE.CONFIG (which is not exposed yet in any other way).