### PR TITLE
add rtic serial interrupt example

### DIFF
--- a/examples/rtic-serial-interrupt/.cargo/config
+++ b/examples/rtic-serial-interrupt/.cargo/config
@@ -1,0 +1,2 @@
+[target.thumbv7em-none-eabihf]
+runner = "arm-none-eabi-gdb -tui"

--- a/examples/rtic-serial-interrupt/.gdbinit
+++ b/examples/rtic-serial-interrupt/.gdbinit
@@ -1,0 +1,10 @@
+set remotetimeout 60000
+target remote :2331
+set arm force-mode thumb
+
+# Uncomment to enable semihosting, when necessary
+monitor semihosting enable
+
+layout split
+monitor reset
+load

--- a/examples/rtic-serial-interrupt/README.md
+++ b/examples/rtic-serial-interrupt/README.md
@@ -1,0 +1,3 @@
+# RTIC demo
+
+The Real-Time Interrupt-driven Concurrency (RTIC) framework demo. Many of the demos in this project use RTIC and demonstrate its capabilities in more detail but this is a bare-bones default template for you to build off. RTIC is not unique to the nRF series but very useful for a program that requires concurrency. 

--- a/examples/rtic-serial-interrupt/src/main.rs
+++ b/examples/rtic-serial-interrupt/src/main.rs
@@ -1,0 +1,80 @@
+#![no_main]
+#![no_std]
+
+#[allow(unused_imports)]
+use panic_semihosting;
+
+use cortex_m_semihosting::hprintln;
+use rtic::app;
+
+#[cfg(feature = "51")]
+use nrf51_hal as hal;
+
+#[cfg(feature = "52810")]
+use nrf52810_hal as hal;
+
+#[cfg(feature = "52811")]
+use nrf52811_hal as hal;
+
+#[cfg(feature = "52832")]
+use nrf52832_hal as hal;
+
+#[cfg(feature = "52833")]
+use nrf52833_hal as hal;
+
+#[cfg(feature = "52840")]
+use nrf52840_hal as hal;
+
+use crate::hal::{
+    gpio::{p0, Level},
+    pac::{Interrupt::UARTE0_UART0, UARTE0},
+    prelude::_embedded_hal_serial_Read,
+    uarte::{self, UarteRx},
+};
+
+#[app(device = crate::hal::pac, peripherals = true)]
+const APP: () = {
+    struct Resources {
+        serial0: UarteRx<UARTE0>,
+    }
+
+    #[init]
+    fn init(cx: init::Context) -> init::LateResources {
+        let p = cx.device;
+        let p0parts = p0::Parts::new(p.P0);
+
+        // enable UARTE0 endrx interrupt
+        p.UARTE0.intenset.modify(|_, w| w.endrx().set_bit());
+
+        static mut SERIAL0_TX_BUF: [u8; 1] = [0; 1];
+        static mut SERIAL0_RX_BUF: [u8; 1] = [0; 1];
+        let (_, serial0) = uarte::Uarte::new(
+            p.UARTE0,
+            uarte::Pins {
+                txd: p0parts.p0_00.into_push_pull_output(Level::High).degrade(),
+                rxd: p0parts.p0_01.into_floating_input().degrade(),
+                cts: None,
+                rts: None,
+            },
+            uarte::Parity::EXCLUDED,
+            uarte::Baudrate::BAUD115200,
+        )
+        .split(unsafe { &mut SERIAL0_TX_BUF }, unsafe {
+            &mut SERIAL0_RX_BUF
+        })
+        .expect("Could not split serial0");
+
+        // on NRF* serial interrupts are only called after the first read
+        rtic::pend(UARTE0_UART0);
+
+        init::LateResources { serial0 }
+    }
+
+    #[task(binds = UARTE0_UART0, resources = [serial0])]
+    fn uarte0_interrupt(cx: uarte0_interrupt::Context) {
+        hprintln!("uarte0 interrupt");
+        while let Ok(b) = cx.resources.serial0.read() {
+            hprintln!("Byte on serial0: {}", b);
+        }
+    }
+};


### PR DESCRIPTION
I'm sorry I didn't get the gdb runnter to run, so I could only test a version with probe-rs (sth similiar like here: https://github.com/elwerene/nrf52833-rtic-serial-interrupt).

It took me some hours to get a working version with lots of help from people hanging around at the nRF Rust Matrix channel.

I also only could test the code on nrf52833. Should I remove the other features, or will it work on them?