### PR TITLE
Add From impl for pins

### DIFF
--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -541,6 +541,12 @@ macro_rules! gpio {
                     }
                 }
 
+                impl<MODE> From<$PXi<MODE>> for Pin<MODE> {
+                    fn from(value: $PXi<MODE>) -> Self {
+                        value.degrade()
+                    }
+                }
+
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     type Error = Void;
 


### PR DESCRIPTION
I ran into this when needing to take a generic struct that could contain any gpio pin. Since all the gpio pins have a degrade function I see no reason to not implement `From`. This allows generic code to work better.