### PR TITLE
Add nrf5340-app-hal

### DIFF
--- a/Cargo.ci.toml
+++ b/Cargo.ci.toml
@@ -7,6 +7,7 @@ members = [
   "nrf52833-hal",
   "nrf52840-hal",
   "nrf52840-hal-tests",
+  "nrf5340-app-hal",
   "nrf9160-hal",
   "examples/*",
 ]

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -60,6 +60,10 @@ version = "0.10.1"
 optional = true
 version = "0.10.1"
 
+[dependencies.nrf5340-app-pac]
+optional = true
+version = "0.10.1"
+
 [dependencies.nrf9160-pac]
 optional = true
 version = "0.10.1"
@@ -80,4 +84,5 @@ doc = []
 52832 = ["nrf52832-pac"]
 52833 = ["nrf52833-pac", "nrf-usbd"]
 52840 = ["nrf52840-pac", "nrf-usbd"]
+5340-app = ["nrf5340-app-pac"]
 9160 = ["nrf9160-pac"]

--- a/nrf-hal-common/src/clocks.rs
+++ b/nrf-hal-common/src/clocks.rs
@@ -1,9 +1,9 @@
 //! Configuration and control of the High and Low Frequency Clock sources.
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::CLOCK_NS as CLOCK;
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::CLOCK;
 
 // ZST Type States
@@ -156,7 +156,7 @@ impl<H, L> Clocks<H, L, LfOscStopped> {
     }
 
     /// Use the internal RC Oscillator for the low frequency clock source.
-    #[cfg(not(any(feature = "9160", feature = "51")))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "51")))]
     pub fn set_lfclk_src_rc(self) -> Clocks<H, Internal, LfOscStopped> {
         self.periph
             .lfclksrc
@@ -170,7 +170,7 @@ impl<H, L> Clocks<H, L, LfOscStopped> {
     }
 
     /// Generate the Low Frequency clock from the high frequency clock source.
-    #[cfg(not(any(feature = "9160", feature = "51")))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "51")))]
     pub fn set_lfclk_src_synth(self) -> Clocks<H, LfOscSynthesized, LfOscStopped> {
         self.periph
             .lfclksrc
@@ -184,7 +184,7 @@ impl<H, L> Clocks<H, L, LfOscStopped> {
     }
 
     /// Use an external crystal to drive the low frequency clock.
-    #[cfg(not(any(feature = "9160", feature = "51")))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "51")))]
     pub fn set_lfclk_src_external(
         self,
         cfg: LfOscConfiguration,

--- a/nrf-hal-common/src/comp.rs
+++ b/nrf-hal-common/src/comp.rs
@@ -4,14 +4,17 @@
 //! Vin can be derived from an analog input pin (AIN0-AIN7).
 //! Vref can be derived from multiple sources depending on the operation mode of the comparator.
 
-use {
-    crate::gpio::{p0::*, Floating, Input},
-    crate::pac::{
-        comp::{extrefsel::EXTREFSEL_A, psel::PSEL_A, EVENTS_CROSS, EVENTS_DOWN, EVENTS_UP},
-        COMP,
-    },
+use crate::gpio::{p0::*, Floating, Input};
+#[cfg(not(feature = "5340-app"))]
+use crate::pac::comp::{
+    extrefsel::EXTREFSEL_A, psel::PSEL_A, EVENTS_CROSS, EVENTS_DOWN, EVENTS_UP,
 };
+use crate::pac::COMP;
 
+#[cfg(feature = "5340-app")]
+use crate::pac::comp_ns::{
+    extrefsel::EXTREFSEL_A, psel::PSEL_A, EVENTS_CROSS, EVENTS_DOWN, EVENTS_UP,
+};
 /// A safe wrapper around the `COMP` peripheral.
 pub struct Comp {
     comp: COMP,

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -37,6 +37,9 @@ pub enum Level {
 pub enum Port {
     /// Port 0, available on all nRF52 and nRF51 MCUs.
     Port0,
+    /// Port 0 Secure, available on nRF53 and nRF9
+    #[cfg(any(feature = "5340-app"))]
+    Port0Secure,
 
     /// Port 1, only available on some nRF52 MCUs.
     #[cfg(any(feature = "52833", feature = "52840"))]
@@ -60,10 +63,13 @@ pub struct Pin<MODE> {
 #[cfg(feature = "51")]
 use crate::pac::{gpio, GPIO as P0};
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "5340-app", feature = "9160"))]
 use crate::pac::{p0_ns as gpio, P0_NS as P0};
 
-#[cfg(not(any(feature = "9160", feature = "51")))]
+#[cfg(feature = "5340-app")]
+use crate::pac::P0_S;
+
+#[cfg(not(any(feature = "9160", feature = "5340-app", feature = "51")))]
 use crate::pac::{p0 as gpio, P0};
 
 #[cfg(any(feature = "52833", feature = "52840"))]
@@ -76,6 +82,8 @@ impl<MODE> Pin<MODE> {
     fn new(port: Port, pin: u8) -> Self {
         let port_bits = match port {
             Port::Port0 => 0x00,
+            #[cfg(any(feature = "5340-app"))]
+            Port::Port0Secure => 0x20,
             #[cfg(any(feature = "52833", feature = "52840"))]
             Port::Port1 => 0x20,
         };
@@ -94,12 +102,12 @@ impl<MODE> Pin<MODE> {
 
     #[inline]
     pub fn pin(&self) -> u8 {
-        #[cfg(any(feature = "52833", feature = "52840"))]
+        #[cfg(any(feature = "52833", feature = "52840", feature = "5340-app"))]
         {
             self.pin_port & 0x1f
         }
 
-        #[cfg(not(any(feature = "52833", feature = "52840")))]
+        #[cfg(not(any(feature = "52833", feature = "52840", feature = "5340-app")))]
         {
             self.pin_port
         }
@@ -116,7 +124,16 @@ impl<MODE> Pin<MODE> {
             }
         }
 
-        #[cfg(not(any(feature = "52833", feature = "52840")))]
+        #[cfg(any(feature = "5340-app"))]
+        {
+            if self.pin_port & 0x20 == 0 {
+                Port::Port0
+            } else {
+                Port::Port0Secure
+            }
+        }
+
+        #[cfg(not(any(feature = "52833", feature = "52840", feature = "5340-app")))]
         {
             Port::Port0
         }
@@ -130,6 +147,8 @@ impl<MODE> Pin<MODE> {
     fn block(&self) -> &gpio::RegisterBlock {
         let ptr = match self.port() {
             Port::Port0 => P0::ptr(),
+            #[cfg(any(feature = "5340-app"))]
+            Port::Port0Secure => P0_S::ptr(),
             #[cfg(any(feature = "52833", feature = "52840"))]
             Port::Port1 => P1::ptr(),
         };
@@ -320,10 +339,10 @@ pub enum OpenDrainConfig {
 #[cfg(feature = "51")]
 use crate::pac::gpio::pin_cnf;
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "5340-app", feature = "9160"))]
 use crate::pac::p0_ns::pin_cnf;
 
-#[cfg(not(any(feature = "9160", feature = "51")))]
+#[cfg(not(any(feature = "9160", feature = "5340-app", feature = "51")))]
 use crate::pac::p0::pin_cnf;
 
 impl OpenDrainConfig {
@@ -640,4 +659,40 @@ gpio!(P1, p0, p1, Port::Port1, [
     P1_13: (p1_13, 13, Disconnected),
     P1_14: (p1_14, 14, Disconnected),
     P1_15: (p1_15, 15, Disconnected),
+]);
+
+#[cfg(any(feature = "5340-app"))]
+gpio!(P0_S, p0, p0_s, Port::Port0Secure, [
+    P0_00: (p0_00,  0, Disconnected),
+    P0_01: (p0_01,  1, Disconnected),
+    P0_02: (p0_02,  2, Disconnected),
+    P0_03: (p0_03,  3, Disconnected),
+    P0_04: (p0_04,  4, Disconnected),
+    P0_05: (p0_05,  5, Disconnected),
+    P0_06: (p0_06,  6, Disconnected),
+    P0_07: (p0_07,  7, Disconnected),
+    P0_08: (p0_08,  8, Disconnected),
+    P0_09: (p0_09,  9, Disconnected),
+    P0_10: (p0_10, 10, Disconnected),
+    P0_11: (p0_11, 11, Disconnected),
+    P0_12: (p0_12, 12, Disconnected),
+    P0_13: (p0_13, 13, Disconnected),
+    P0_14: (p0_14, 14, Disconnected),
+    P0_15: (p0_15, 15, Disconnected),
+    P0_16: (p0_16, 16, Disconnected),
+    P0_17: (p0_17, 17, Disconnected),
+    P0_18: (p0_18, 18, Disconnected),
+    P0_19: (p0_19, 19, Disconnected),
+    P0_20: (p0_20, 20, Disconnected),
+    P0_21: (p0_21, 21, Disconnected),
+    P0_22: (p0_22, 22, Disconnected),
+    P0_23: (p0_23, 23, Disconnected),
+    P0_24: (p0_24, 24, Disconnected),
+    P0_25: (p0_25, 25, Disconnected),
+    P0_26: (p0_26, 26, Disconnected),
+    P0_27: (p0_27, 27, Disconnected),
+    P0_28: (p0_28, 28, Disconnected),
+    P0_29: (p0_29, 29, Disconnected),
+    P0_30: (p0_30, 30, Disconnected),
+    P0_31: (p0_31, 31, Disconnected),
 ]);

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -37,7 +37,7 @@ pub enum Level {
 pub enum Port {
     /// Port 0, available on all nRF52 and nRF51 MCUs.
     Port0,
-    /// Port 0 Secure, available on nRF53 and nRF9
+    /// Port 0 Secure, available on nRF53
     #[cfg(any(feature = "5340-app"))]
     Port0Secure,
 

--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -200,7 +200,12 @@ impl I2S {
         self.i2s
             .config
             .swidth
-            .write(|w| unsafe { w.swidth().bits(width.into()) });
+            .write(|w| {
+                   #[cfg(not(feature = "5340-app"))]
+                   unsafe { w.swidth().bits(width.into()) }
+                   #[cfg(feature = "5340-app")]
+                   w.swidth().bits(width.into())
+            });
         self
     }
 

--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -1,8 +1,10 @@
 //! HAL interface for the I2S peripheral.
 //!
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "5340-app", feature = "9160")))]
 use crate::pac::{i2s, I2S as I2S_PAC};
+#[cfg(feature = "5340-app")]
+use crate::pac::{i2s0_ns as i2s, I2S0_NS as I2S_PAC};
 #[cfg(feature = "9160")]
 use crate::pac::{i2s_ns as i2s, I2S_NS as I2S_PAC};
 use crate::{

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -24,49 +24,57 @@ pub use nrf52833_pac as pac;
 #[cfg(feature = "52840")]
 pub use nrf52840_pac as pac;
 
+#[cfg(feature = "5340-app")]
+pub use nrf5340_app_pac as pac;
+
 #[cfg(feature = "9160")]
 pub use nrf9160_pac as pac;
 
 #[cfg(feature = "51")]
 pub mod adc;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod ccm;
 pub mod clocks;
-#[cfg(not(any(feature = "51", feature = "9160")))]
+#[cfg(not(any(feature = "51", feature = "9160", feature = "5340-app")))]
 pub mod comp;
 #[cfg(not(feature = "51"))]
 pub mod delay;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod ecb;
 pub mod gpio;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod gpiote;
 #[cfg(not(any(feature = "51", feature = "52810", feature = "52811")))]
 pub mod i2s;
 #[cfg(any(feature = "52833", feature = "52840"))]
 pub mod ieee802154;
-#[cfg(not(any(feature = "52811", feature = "52810", feature = "9160")))]
+#[cfg(not(any(
+    feature = "52811",
+    feature = "52810",
+    feature = "9160",
+    feature = "5340-app"
+)))]
 pub mod lpcomp;
 #[cfg(not(feature = "51"))]
 pub mod nvmc;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod ppi;
 #[cfg(not(feature = "51"))]
 pub mod pwm;
-#[cfg(not(any(feature = "51", feature = "9160")))]
+#[cfg(not(any(feature = "51", feature = "9160", feature = "5340-app")))]
 pub mod qdec;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod rng;
 pub mod rtc;
 #[cfg(not(feature = "51"))]
 pub mod saadc;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod spi;
 #[cfg(not(feature = "51"))]
 pub mod spim;
 #[cfg(not(feature = "51"))]
 pub mod spis;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod temp;
 pub mod time;
 pub mod timer;
@@ -80,7 +88,7 @@ pub mod twis;
 pub mod uart;
 #[cfg(not(feature = "51"))]
 pub mod uarte;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub mod uicr;
 #[cfg(feature = "nrf-usbd")]
 pub mod usbd;
@@ -90,7 +98,7 @@ pub mod prelude {
     pub use crate::hal::digital::v2::*;
     pub use crate::hal::prelude::*;
 
-    #[cfg(not(feature = "9160"))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app")))]
     pub use crate::ppi::{ConfigurablePpi, Ppi};
     pub use crate::time::U32Ext;
 }
@@ -113,7 +121,7 @@ pub mod target_constants {
     pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
     #[cfg(feature = "52840")]
     pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
-    #[cfg(feature = "5340")]
+    #[cfg(feature = "5340-app")]
     pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
     #[cfg(feature = "9160")]
     pub const EASY_DMA_SIZE: usize = (1 << 12) - 1;
@@ -172,7 +180,7 @@ impl DmaSlice {
 pub use crate::clocks::Clocks;
 #[cfg(not(feature = "51"))]
 pub use crate::delay::Delay;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 pub use crate::rng::Rng;
 pub use crate::rtc::Rtc;
 pub use crate::timer::Timer;

--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -2,13 +2,13 @@
 
 use core::ops::Deref;
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::nvmc;
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::nvmc_ns as nvmc;
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::NVMC;
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::NVMC_NS as NVMC;
 
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
@@ -34,23 +34,23 @@ where
     }
 
     fn enable_erase(&self) {
-        #[cfg(not(feature = "9160"))]
+        #[cfg(not(any(feature = "9160", feature = "5340-app")))]
         self.nvmc.config.write(|w| w.wen().een());
-        #[cfg(feature = "9160")]
+        #[cfg(any(feature = "9160", feature = "5340-app"))]
         self.nvmc.configns.write(|w| w.wen().een());
     }
 
     fn enable_read(&self) {
-        #[cfg(not(feature = "9160"))]
+        #[cfg(not(any(feature = "9160", feature = "5340-app")))]
         self.nvmc.config.write(|w| w.wen().ren());
-        #[cfg(feature = "9160")]
+        #[cfg(any(feature = "9160", feature = "5340-app"))]
         self.nvmc.configns.write(|w| w.wen().ren());
     }
 
     fn enable_write(&self) {
-        #[cfg(not(feature = "9160"))]
+        #[cfg(not(any(feature = "9160", feature = "5340-app")))]
         self.nvmc.config.write(|w| w.wen().wen());
-        #[cfg(feature = "9160")]
+        #[cfg(any(feature = "9160", feature = "5340-app"))]
         self.nvmc.configns.write(|w| w.wen().wen());
     }
 
@@ -59,13 +59,13 @@ where
         while !self.nvmc.ready.read().ready().bit_is_set() {}
     }
 
-    #[cfg(feature = "9160")]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     #[inline]
     fn wait_write_ready(&self) {
         while !self.nvmc.readynext.read().readynext().bit_is_set() {}
     }
 
-    #[cfg(not(feature = "9160"))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app")))]
     #[inline]
     fn erase_page(&mut self, offset: usize) {
         let bits = &mut (self.storage[offset as usize >> 2]) as *mut _ as u32;
@@ -73,7 +73,7 @@ where
         self.wait_ready();
     }
 
-    #[cfg(feature = "9160")]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     #[inline]
     fn erase_page(&mut self, offset: usize) {
         self.storage[offset as usize >> 2] = 0xffffffff;
@@ -82,9 +82,9 @@ where
 
     #[inline]
     fn write_word(&mut self, offset: usize, word: u32) {
-        #[cfg(not(feature = "9160"))]
+        #[cfg(not(any(feature = "9160", feature = "5340-app")))]
         self.wait_ready();
-        #[cfg(feature = "9160")]
+        #[cfg(any(feature = "9160", feature = "5340-app"))]
         self.wait_write_ready();
         self.storage[offset] = word;
         cortex_m::asm::dmb();

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -2,10 +2,11 @@
 //!
 //! The pulse with modulation (PWM) module enables the generation of pulse width modulated signals on GPIO.
 
-#[cfg(not(any(feature = "9160")))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::pwm0::*;
-#[cfg(any(feature = "9160"))]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::pwm0_ns::*;
+
 use crate::{
     gpio::{Output, Pin, PushPull},
     pac::Interrupt,
@@ -1117,7 +1118,7 @@ static mut BUF2: Cell<[u16; 4]> = Cell::new([0; 4]);
 #[cfg(not(any(feature = "52810", feature = "52811", feature = "52832")))]
 static mut BUF3: Cell<[u16; 4]> = Cell::new([0; 4]);
 
-#[cfg(not(any(feature = "9160")))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 impl Instance for crate::pac::PWM0 {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
@@ -1126,7 +1127,12 @@ impl Instance for crate::pac::PWM0 {
     }
 }
 
-#[cfg(not(any(feature = "52810", feature = "52811", feature = "9160")))]
+#[cfg(not(any(
+    feature = "52810",
+    feature = "52811",
+    feature = "9160",
+    feature = "5340-app"
+)))]
 impl Instance for crate::pac::PWM1 {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> &'static Cell<[u16; 4]> {
@@ -1134,7 +1140,12 @@ impl Instance for crate::pac::PWM1 {
     }
 }
 
-#[cfg(not(any(feature = "52810", feature = "52811", feature = "9160")))]
+#[cfg(not(any(
+    feature = "52810",
+    feature = "52811",
+    feature = "9160",
+    feature = "5340-app"
+)))]
 impl Instance for crate::pac::PWM2 {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> &'static Cell<[u16; 4]> {
@@ -1146,6 +1157,7 @@ impl Instance for crate::pac::PWM2 {
     feature = "52810",
     feature = "52811",
     feature = "52832",
+    feature = "5340-app",
     feature = "9160"
 )))]
 impl Instance for crate::pac::PWM3 {
@@ -1155,7 +1167,7 @@ impl Instance for crate::pac::PWM3 {
     }
 }
 
-#[cfg(any(feature = "9160"))]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM0_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
@@ -1164,7 +1176,7 @@ impl Instance for crate::pac::PWM0_NS {
     }
 }
 
-#[cfg(any(feature = "9160"))]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM1_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> &'static Cell<[u16; 4]> {
@@ -1172,7 +1184,7 @@ impl Instance for crate::pac::PWM1_NS {
     }
 }
 
-#[cfg(any(feature = "9160"))]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM2_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> &'static Cell<[u16; 4]> {
@@ -1180,7 +1192,7 @@ impl Instance for crate::pac::PWM2_NS {
     }
 }
 
-#[cfg(any(feature = "9160"))]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM3_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
     fn buffer() -> &'static Cell<[u16; 4]> {
@@ -1190,32 +1202,43 @@ impl Instance for crate::pac::PWM3_NS {
 mod sealed {
     pub trait Sealed {}
 
-    #[cfg(not(any(feature = "9160")))]
+    #[cfg(not(any(feature = "5340-app", feature = "9160")))]
     impl Sealed for crate::pac::PWM0 {}
 
-    #[cfg(not(any(feature = "52810", feature = "52811", feature = "9160")))]
+    #[cfg(not(any(
+        feature = "52810",
+        feature = "52811",
+        feature = "5340-app",
+        feature = "9160"
+    )))]
     impl Sealed for crate::pac::PWM1 {}
 
-    #[cfg(not(any(feature = "52810", feature = "52811", feature = "9160")))]
+    #[cfg(not(any(
+        feature = "52810",
+        feature = "52811",
+        feature = "5340-app",
+        feature = "9160"
+    )))]
     impl Sealed for crate::pac::PWM2 {}
 
     #[cfg(not(any(
         feature = "52810",
         feature = "52811",
         feature = "52832",
+        feature = "5340-app",
         feature = "9160"
     )))]
     impl Sealed for crate::pac::PWM3 {}
 
-    #[cfg(any(feature = "9160"))]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     impl Sealed for crate::pac::PWM0_NS {}
 
-    #[cfg(any(feature = "9160"))]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     impl Sealed for crate::pac::PWM1_NS {}
 
-    #[cfg(any(feature = "9160"))]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     impl Sealed for crate::pac::PWM2_NS {}
 
-    #[cfg(any(feature = "9160"))]
+    #[cfg(any(feature = "9160", feature = "5340-app"))]
     impl Sealed for crate::pac::PWM3_NS {}
 }

--- a/nrf-hal-common/src/rtc.rs
+++ b/nrf-hal-common/src/rtc.rs
@@ -2,10 +2,10 @@
 
 use core::ops::Deref;
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{rtc0_ns as rtc0, Interrupt, NVIC, RTC0_NS as RTC0, RTC1_NS as RTC1};
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{rtc0, Interrupt, NVIC, RTC0, RTC1};
 
 #[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -26,10 +26,10 @@
 //! let _saadc_result = saadc.read(&mut saadc_pin);
 //! ```
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{saadc_ns as saadc, SAADC_NS as SAADC};
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{saadc, SAADC};
 
 use core::{

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -5,10 +5,10 @@
 use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{spim0_ns as spim0, SPIM0_NS as SPIM0};
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{spim0, SPIM0};
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -7,7 +7,7 @@ use core::{
     sync::atomic::{compiler_fence, Ordering},
 };
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{
     spis0_ns::{
         self as spis0, EVENTS_ACQUIRED, EVENTS_END, EVENTS_ENDRX, TASKS_ACQUIRE, TASKS_RELEASE,
@@ -15,7 +15,7 @@ use crate::pac::{
     SPIS0_NS as SPIS0,
 };
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{
     spis0::{self, EVENTS_ACQUIRED, EVENTS_END, EVENTS_ENDRX, TASKS_ACQUIRE, TASKS_RELEASE},
     SPIS0,
@@ -593,9 +593,14 @@ pub struct Pins {
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::SPIS0 {}
-    #[cfg(not(any(feature = "9160", feature = "52810")))]
+    #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "52810")))]
     impl Sealed for super::SPIS1 {}
-    #[cfg(not(any(feature = "9160", feature = "52811", feature = "52810")))]
+    #[cfg(not(any(
+        feature = "9160",
+        feature = "5340-app",
+        feature = "52811",
+        feature = "52810"
+    )))]
     impl Sealed for super::SPIS2 {}
 }
 
@@ -604,17 +609,24 @@ pub trait Instance: sealed::Sealed + Deref<Target = spis0::RegisterBlock> {
 }
 
 impl Instance for SPIS0 {
-    #[cfg(not(any(feature = "9160", feature = "52811", feature = "52810")))]
+    #[cfg(not(any(
+        feature = "9160",
+        feature = "5340-app",
+        feature = "52811",
+        feature = "52810"
+    )))]
     const INTERRUPT: Interrupt = Interrupt::SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0;
     #[cfg(feature = "9160")]
     const INTERRUPT: Interrupt = Interrupt::UARTE0_SPIM0_SPIS0_TWIM0_TWIS0;
+    #[cfg(feature = "5340-app")]
+    const INTERRUPT: Interrupt = Interrupt::SERIAL0;
     #[cfg(feature = "52810")]
     const INTERRUPT: Interrupt = Interrupt::SPIM0_SPIS0_SPI0;
     #[cfg(feature = "52811")]
     const INTERRUPT: Interrupt = Interrupt::TWIM0_TWIS0_TWI0_SPIM0_SPIS0_SPI0;
 }
 
-#[cfg(not(any(feature = "9160", feature = "52810")))]
+#[cfg(not(any(feature = "9160", feature = "5340-app", feature = "52810")))]
 impl Instance for SPIS1 {
     #[cfg(not(feature = "52811"))]
     const INTERRUPT: Interrupt = Interrupt::SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1;
@@ -622,7 +634,12 @@ impl Instance for SPIS1 {
     const INTERRUPT: Interrupt = Interrupt::SPIM1_SPIS1_SPI1;
 }
 
-#[cfg(not(any(feature = "9160", feature = "52811", feature = "52810")))]
+#[cfg(not(any(
+    feature = "9160",
+    feature = "5340-app",
+    feature = "52811",
+    feature = "52810"
+)))]
 impl Instance for SPIS2 {
     const INTERRUPT: Interrupt = Interrupt::SPIM2_SPIS2_SPI2;
 }

--- a/nrf-hal-common/src/timer.rs
+++ b/nrf-hal-common/src/timer.rs
@@ -2,7 +2,7 @@
 //!
 //! See product specification, chapter 24.
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{
     timer0_ns::{
         RegisterBlock as RegBlock0, EVENTS_COMPARE, TASKS_CAPTURE, TASKS_CLEAR, TASKS_COUNT,
@@ -11,7 +11,7 @@ use crate::pac::{
     Interrupt, TIMER0_NS as TIMER0, TIMER1_NS as TIMER1, TIMER2_NS as TIMER2,
 };
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{
     timer0::{
         RegisterBlock as RegBlock0, EVENTS_COMPARE, TASKS_CAPTURE, TASKS_CLEAR, TASKS_COUNT,

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -7,12 +7,12 @@
 use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{
     twim0_ns as twim0, TWIM0_NS as TWIM0, TWIM1_NS as TWIM1, TWIM2_NS as TWIM2, TWIM3_NS as TWIM3,
 };
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{twim0, TWIM0};
 
 #[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
@@ -473,7 +473,8 @@ impl Instance for TWIM0 {}
     feature = "52832",
     feature = "52833",
     feature = "52840",
-    feature = "9160"
+    feature = "9160",
+    feature = "5340-app",
 ))]
 mod _twim1 {
     use super::*;
@@ -481,14 +482,14 @@ mod _twim1 {
     impl Instance for TWIM1 {}
 }
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 mod _twim2 {
     use super::*;
     impl sealed::Sealed for TWIM2 {}
     impl Instance for TWIM2 {}
 }
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 mod _twim3 {
     use super::*;
     impl sealed::Sealed for TWIM3 {}

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -6,10 +6,10 @@ use core::{
     sync::atomic::{compiler_fence, Ordering::SeqCst},
 };
 
-#[cfg(feature = "9160")]
+#[cfg(any(feature = "9160", feature = "5340-app"))]
 use crate::pac::{twis0_ns as twis0, P0_NS as P0, TWIS0_NS as TWIS0};
 
-#[cfg(not(feature = "9160"))]
+#[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{twis0, P0, TWIS0};
 
 #[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
@@ -538,8 +538,15 @@ pub trait Instance: sealed::Sealed + Deref<Target = twis0::RegisterBlock> {
 }
 
 impl Instance for TWIS0 {
-    #[cfg(not(any(feature = "9160", feature = "52810", feature = "52811")))]
+    #[cfg(not(any(
+        feature = "9160",
+        feature = "5340-app",
+        feature = "52810",
+        feature = "52811"
+    )))]
     const INTERRUPT: Interrupt = Interrupt::SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0;
+    #[cfg(feature = "5340-app")]
+    const INTERRUPT: Interrupt = Interrupt::SERIAL0;
     #[cfg(feature = "9160")]
     const INTERRUPT: Interrupt = Interrupt::UARTE0_SPIM0_SPIS0_TWIM0_TWIS0;
     #[cfg(feature = "52810")]

--- a/nrf-hal-common/src/wdt.rs
+++ b/nrf-hal-common/src/wdt.rs
@@ -8,11 +8,12 @@ use cfg_if::cfg_if;
 cfg_if! {
     if #[cfg(feature = "9160")] {
         use crate::pac::WDT_NS as WDT;
+    } else if #[cfg(feature = "5340-app")] {
+        use crate::pac::WDT0_NS as WDT;
     } else {
         use crate::pac::WDT;
     }
 }
-
 
 use handles::*;
 
@@ -213,7 +214,7 @@ where
     #[inline(always)]
     pub fn is_active(&self) -> bool {
         cfg_if! {
-            if #[cfg(feature = "9160")] {
+            if #[cfg(any(feature = "9160", feature = "5340-app"))] {
                 self.wdt.runstatus.read().runstatuswdt().bit_is_set()
             } else {
                 self.wdt.runstatus.read().runstatus().bit_is_set()

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf5340-app-hal"
-version = "0.0.1"
+version = "0.14.0"
 description = "HAL for nRF5340 app SoC"
 readme = "../README.md"
 

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "nrf5340-app-hal"
+version = "0.0.1"
+description = "HAL for nRF5340 app SoC"
+readme = "../README.md"
+
+repository = "https://github.com/nrf-rs/nrf-hal"
+authors = [
+    "Jonathan Pallant (42 Technology) <jonathan.pallant@42technology.com>",
+    "Sascha Wise <me@saschawise.com"
+]
+
+categories = ["embedded", "hardware-support", "no-std"]
+keywords = ["arm", "cortex-m", "nrf53", "hal", "nrf5340"]
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+nrf5340-app-pac = "0.10.1"
+
+[dependencies.nrf-hal-common]
+path = "../nrf-hal-common"
+default-features = false
+features = ["5340-app"]
+version = "=0.14.0"
+
+[dependencies.embedded-hal]
+features = ["unproven"]
+version = "0.2.3"
+
+[features]
+doc = []
+rt = ["nrf5340-app-pac/rt"]
+default = ["rt"]

--- a/nrf5340-app-hal/README.md
+++ b/nrf5340-app-hal/README.md
@@ -1,0 +1,78 @@
+# Hardware Abstration Layer for the Nordic nRF5340
+
+This crate is a Hardware Abstraction Layer (HAL) for the Nordic nRF5340. It
+wraps the PAC (`nrf5340-pac`) and provides high level wrappers for the chip's
+peripherals.
+
+This crate knows nothing about your PCB layout, or which pins you have assigned
+to which functions. The only exception are the examples, which are written to
+run on the official nRF5340-DK developer kit.
+
+## Usage
+
+You will require the `thumbv8m.main-none-eabihf` target installed.
+
+```console
+$ rustup target add thumbv8m.main-none-eabihf
+```
+
+## Secure vs Non-Secure
+
+This HAL is designed to run in non-secure mode, as should most of your
+application code. You will therefore need a 'bootloader' which starts in secure
+mode, moves the required peripherals into 'non-secure' world, and then jumps to
+your application.
+
+We have succesfully used Nordic's [Secure Partition Manager](https://github.com/nrfconnect/sdk-nrf/tree/v1.7/samples/spm)
+from nRF SDK v1.7. SPM v1.7 is configured to expect your application at address
+`0x0005_0000` and so that is what `memory.x` must specify as the start of Flash.
+
+_Note:_ Other versions of SPM might expect a different start address -
+especially those compiled as a child image of another application (like
+`at_sample`)! You can see the start address on boot-up:
+
+```
+SPM: NS image at 0x50000
+```
+
+This tells you SPM is looking for a non-secure (NS) image at `0x0005_0000`.
+
+To build SPM, run:
+
+```console
+$ west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.5.1 ncs
+$ cd ncs
+$ west update # This takes *ages*
+$ cd nrf/examples/spm
+$ west build --board=nrf5340dk_nrf5340_cpuapp
+$ west flash
+```
+
+West is a Python tool supplied by Nordic for building the nRF Connect SDK. See
+[Nordic's website](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/1.5.1/nrf/gs_installing.html)
+for more details.
+
+Your nRF5340-DK will now have SPM installed between `0x0000_0000` and
+`0x0004_FFFF`. Flashing your application at `0x0005_0000` should not affect SPM,
+provided you do not select *erase entire chip* or somesuch!
+
+If you want to change the flash address, supply your own `memory.x` file in your
+application crate (or your Board Support Crate) and write a `build.rs` file that
+copies your `memory.x` over the top of this one.
+
+## Licence
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option.
+
+## Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally
+submitted for inclusion in the work by you, as defined in the Apache-2.0
+license, shall be dual licensed as above, without any additional terms or
+conditions.

--- a/nrf5340-app-hal/build.rs
+++ b/nrf5340-app-hal/build.rs
@@ -1,0 +1,17 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=memory.x");
+}

--- a/nrf5340-app-hal/memory.x
+++ b/nrf5340-app-hal/memory.x
@@ -1,0 +1,27 @@
+/* Linker script for the nRF5340 in Non-secure mode. It assumes you have the
+Nordic Secure Partition Manager installed at the bottom of flash and that
+the SPM is set to boot a non-secure application from the FLASH origin below. */
+
+MEMORY
+{
+    /*
+     * This is where the Bootloader, Secure Partition Manager or
+     * Trusted-Firmware-M lives.
+     */
+    /*
+    SECURE_FLASH : ORIGIN = 0x00000000, LENGTH = 256K
+     * This is where your non-secure Rust application lives. Note that SPM must agree this
+     * is where your application lives, or it will jump to garbage and crash the CPU.
+     SIG          : ORIGIN =  0x00050000, LENGTH = 1K
+     */
+      FLASH        : ORIGIN = 0x00050000, LENGTH = 767K 
+      /* FLASH        : ORIGIN = 0x00000000, LENGTH = 767K  */
+    /*
+     * This RAM is reserved for the Secure-Mode code located in the `SECURE_FLASH` region.
+     */
+     SECURE_RAM   : ORIGIN = 0x20000000, LENGTH = 64K
+     /*
+     * This RAM is available to your non-secure Rust application.
+     */
+    RAM          : ORIGIN = 0x20020000, LENGTH = 128K
+}

--- a/nrf5340-app-hal/src/lib.rs
+++ b/nrf5340-app-hal/src/lib.rs
@@ -1,0 +1,20 @@
+#![no_std]
+
+use embedded_hal as hal;
+pub use nrf_hal_common::*;
+
+pub mod prelude {
+    pub use crate::hal::prelude::*;
+    pub use nrf_hal_common::prelude::*;
+
+    pub use crate::time::U32Ext;
+}
+
+pub use crate::clocks::Clocks;
+pub use crate::delay::Delay;
+pub use crate::rtc::Rtc;
+pub use crate::saadc::Saadc;
+pub use crate::spim::Spim;
+pub use crate::timer::Timer;
+pub use crate::twim::Twim;
+pub use crate::uarte::Uarte;

--- a/nrf5340-app-hal/src/lib.rs
+++ b/nrf5340-app-hal/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![doc(html_root_url = "https://docs.rs/nrf5340-app-hal/0.14.0")]
 
 use embedded_hal as hal;
 pub use nrf_hal_common::*;

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -3,6 +3,7 @@ use std::{fs, process::Command};
 pub static HALS: &[(&str, &str)] = &[
     ("nrf51-hal", "thumbv6m-none-eabi"),
     ("nrf9160-hal", "thumbv8m.main-none-eabihf"),
+    ("nrf5340-app-hal", "thumbv8m.main-none-eabihf"),
     ("nrf52810-hal", "thumbv7em-none-eabi"),
     ("nrf52811-hal", "thumbv7em-none-eabi"),
     ("nrf52832-hal", "thumbv7em-none-eabihf"),
@@ -47,7 +48,7 @@ pub fn feature_to_target(feat: &str) -> &str {
     match feat {
         "51" => "thumbv6m-none-eabi",
         "52810" | "52811" => "thumbv7em-none-eabi",
-        "9160" => "thumbv8m.main-none-eabihf",
+        "9160" | "5340-app" => "thumbv8m.main-none-eabihf",
         _ if feat.starts_with("52") => "thumbv7em-none-eabihf",
         _ => panic!("unknown Cargo feature `{}`", feat),
     }


### PR DESCRIPTION
This PR adds a HAL for the nRF5340's app core. It is more or less identical to the nRF9160 HAL that already exists, with some features added or removed for the nRF5340. I have not added support for the net core yet, as I don't need it for my use case. 