### PR TITLE
ieee802154: handle the transitory state TXDISABLE

### DIFF
--- a/nrf-hal-common/src/ieee802154.rs
+++ b/nrf-hal-common/src/ieee802154.rs
@@ -659,9 +659,17 @@ impl<'c> Radio<'c> {
 
     fn state(&self) -> State {
         match self.radio.state.read().state().variant().unwrap() {
+            // final states
             STATE_A::DISABLED => State::Disabled,
             STATE_A::TXIDLE => State::TxIdle,
             STATE_A::RXIDLE => State::RxIdle,
+
+            // transitory states
+            STATE_A::TXDISABLE => {
+                self.wait_for_state_a(STATE_A::DISABLED);
+                State::Disabled
+            }
+
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
after PR #356 the radio is disabled after every `send` operation.
if one calls `recv` immediately after `send`, `recv` can observe the radio in the TXDISABLE state
TXDISABLE is a transitory state that leads to the final DISABLED state which the impl knows how to handle

this PR adds logic to handle the transitory TXDISABLE state

fixes #368

---

I have checked that the programs in https://github.com/ferrous-systems/embedded-trainings-2020 work again with this change