### PR TITLE
Unified how pins are return in `free` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
-(no changes)
+### Changed
+
+- Unified how pins are are returned in `free` calls
 
 ## [0.14.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Changed
 
-- Unified how pins are are returned in `free` calls
+- Unified how pins are are returned in `free` calls ([#372]).
+
+[#372]: https://github.com/nrf-rs/nrf-hal/pull/372
 
 ## [0.14.1]
 

--- a/examples/i2s-peripheral-demo/src/main.rs
+++ b/examples/i2s-peripheral-demo/src/main.rs
@@ -12,9 +12,9 @@ use {
     },
     hal::{
         gpio::Level,
-        i2s::*,
+        i2s::{self, *},
         pac::SPIM0,
-        spim::{Frequency, Mode as SPIMode, Phase, Pins, Polarity, Spim},
+        spim::{self, Frequency, Mode as SPIMode, Phase, Polarity, Spim},
     },
     nrf52840_hal as hal,
     rtt_target::{rprintln, rtt_init_print},
@@ -45,19 +45,17 @@ const APP: () = {
         rprintln!("Play me some audio...");
 
         let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
-        let mck_pin = p0.p0_25.into_floating_input().degrade();
-        let sck_pin = p0.p0_24.into_floating_input().degrade();
-        let lrck_pin = p0.p0_16.into_floating_input().degrade();
-        let sdin_pin = p0.p0_14.into_floating_input().degrade();
 
         // Configure I2S reception
-        let i2s = I2S::new_peripheral(
+        let i2s = I2S::new(
             ctx.device.I2S,
-            Some(&mck_pin),
-            &sck_pin,
-            &lrck_pin,
-            Some(&sdin_pin),
-            None,
+            i2s::Pins::Peripheral {
+                mck: Some(p0.p0_25.into_floating_input().degrade()),
+                sck: p0.p0_24.into_floating_input().degrade(),
+                lrck: p0.p0_16.into_floating_input().degrade(),
+                sdin: Some(p0.p0_14.into_floating_input().degrade()),
+                sdout: None,
+            },
         );
         i2s.enable_interrupt(I2SEvent::RxPtrUpdated).start();
 
@@ -68,7 +66,7 @@ const APP: () = {
 
         let rgb = Spim::new(
             ctx.device.SPIM0,
-            Pins {
+            spim::Pins {
                 miso: None,
                 mosi: Some(rgb_data_pin),
                 sck: rgb_clk_pin,

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -25,10 +25,13 @@ const APP: () = {
         rtt_init_print!();
 
         let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
-        let pin_a = p0.p0_31.into_pullup_input().degrade();
-        let pin_b = p0.p0_30.into_pullup_input().degrade();
+        let pins = Pins {
+            a: p0.p0_31.into_pullup_input().degrade(),
+            b: p0.p0_30.into_pullup_input().degrade(),
+            led: None,
+        };
 
-        let qdec = Qdec::new(ctx.device.QDEC, pin_a, pin_b, None, SamplePeriod::_128us);
+        let qdec = Qdec::new(ctx.device.QDEC, pins, SamplePeriod::_128us);
         qdec.debounce(true)
             .enable_interrupt(NumSamples::_1smpl)
             .enable();

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -761,6 +761,10 @@ where
         let ch1 = self.pwm.psel.out[1].read();
         let ch2 = self.pwm.psel.out[2].read();
         let ch3 = self.pwm.psel.out[3].read();
+        self.pwm.psel.out[0].reset();
+        self.pwm.psel.out[1].reset();
+        self.pwm.psel.out[2].reset();
+        self.pwm.psel.out[3].reset();
         (
             self.pwm,
             if ch0.connect().bit_is_set() {

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -748,15 +748,7 @@ where
     }
 
     /// Consumes `self` and returns back the raw peripheral.
-    pub fn free(
-        self,
-    ) -> (
-        T,
-        Option<Pin<Output<PushPull>>>,
-        Option<Pin<Output<PushPull>>>,
-        Option<Pin<Output<PushPull>>>,
-        Option<Pin<Output<PushPull>>>,
-    ) {
+    pub fn free(self) -> (T, Pins) {
         let ch0 = self.pwm.psel.out[0].read();
         let ch1 = self.pwm.psel.out[1].read();
         let ch2 = self.pwm.psel.out[2].read();
@@ -767,28 +759,42 @@ where
         self.pwm.psel.out[3].reset();
         (
             self.pwm,
-            if ch0.connect().bit_is_set() {
-                Some(unsafe { Pin::from_psel_bits(ch0.bits()) })
-            } else {
-                None
-            },
-            if ch1.connect().bit_is_set() {
-                Some(unsafe { Pin::from_psel_bits(ch1.bits()) })
-            } else {
-                None
-            },
-            if ch2.connect().bit_is_set() {
-                Some(unsafe { Pin::from_psel_bits(ch2.bits()) })
-            } else {
-                None
-            },
-            if ch3.connect().bit_is_set() {
-                Some(unsafe { Pin::from_psel_bits(ch3.bits()) })
-            } else {
-                None
+            Pins {
+                ch0: if ch0.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(ch0.bits()) })
+                } else {
+                    None
+                },
+                ch1: if ch1.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(ch1.bits()) })
+                } else {
+                    None
+                },
+                ch2: if ch2.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(ch2.bits()) })
+                } else {
+                    None
+                },
+                ch3: if ch3.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(ch3.bits()) })
+                } else {
+                    None
+                },
             },
         )
     }
+}
+
+/// Pins for the Pwm
+pub struct Pins {
+    /// Channel 0 pin, `None` if it was unused
+    pub ch0: Option<Pin<Output<PushPull>>>,
+    /// Channel 1 pin, `None` if it was unused
+    pub ch1: Option<Pin<Output<PushPull>>>,
+    /// Channel 2 pin, `None` if it was unused
+    pub ch2: Option<Pin<Output<PushPull>>>,
+    /// Channel 3 pin, `None` if it was unused
+    pub ch3: Option<Pin<Output<PushPull>>>,
 }
 
 /// A Pwm sequence wrapper

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -748,8 +748,42 @@ where
     }
 
     /// Consumes `self` and returns back the raw peripheral.
-    pub fn free(self) -> T {
-        self.pwm
+    pub fn free(
+        self,
+    ) -> (
+        T,
+        Option<Pin<Output<PushPull>>>,
+        Option<Pin<Output<PushPull>>>,
+        Option<Pin<Output<PushPull>>>,
+        Option<Pin<Output<PushPull>>>,
+    ) {
+        let ch0 = self.pwm.psel.out[0].read();
+        let ch1 = self.pwm.psel.out[1].read();
+        let ch2 = self.pwm.psel.out[2].read();
+        let ch3 = self.pwm.psel.out[3].read();
+        (
+            self.pwm,
+            if ch0.connect().bit_is_set() {
+                Some(unsafe { Pin::from_psel_bits(ch0.bits()) })
+            } else {
+                None
+            },
+            if ch1.connect().bit_is_set() {
+                Some(unsafe { Pin::from_psel_bits(ch1.bits()) })
+            } else {
+                None
+            },
+            if ch2.connect().bit_is_set() {
+                Some(unsafe { Pin::from_psel_bits(ch2.bits()) })
+            } else {
+                None
+            },
+            if ch3.connect().bit_is_set() {
+                Some(unsafe { Pin::from_psel_bits(ch3.bits()) })
+            } else {
+                None
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -157,6 +157,9 @@ impl Qdec {
                 None
             }
         };
+        self.qdec.psel.a.reset();
+        self.qdec.psel.b.reset();
+        self.qdec.psel.led.reset();
 
         (self.qdec, pin_a, pin_b, pin_led)
     }

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -97,12 +97,23 @@ where
             .write(|w| unsafe { w.bits(pins.sck.pin().into()) });
 
         // Optional pins.
-        if let Some(ref pin) = pins.mosi {
-            spi.pselmosi.write(|w| unsafe { w.bits(pin.pin().into()) });
-        }
-        if let Some(ref pin) = pins.miso {
-            spi.pselmiso.write(|w| unsafe { w.bits(pin.pin().into()) });
-        }
+        spi.pselmosi.write(|w| unsafe {
+            if let Some(ref pin) = pins.mosi {
+                w.bits(pin.pin().into())
+            } else {
+                // Disconnect
+                w.bits(0xFFFFFFFF)
+            }
+        });
+
+        spi.pselmiso.write(|w| unsafe {
+            if let Some(ref pin) = pins.miso {
+                w.bits(pin.pin().into())
+            } else {
+                // Disconnect
+                w.bits(0xFFFFFFFF)
+            }
+        });
     }
 
     #[cfg(not(feature = "51"))]

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -362,6 +362,9 @@ where
         let sck = self.0.psel.sck.read();
         let mosi = self.0.psel.mosi.read();
         let miso = self.0.psel.miso.read();
+        self.0.psel.sck.reset();
+        self.0.psel.mosi.reset();
+        self.0.psel.miso.reset();
         (
             self.0,
             Pins {

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -358,8 +358,26 @@ where
     }
 
     /// Return the raw interface to the underlying SPIM peripheral.
-    pub fn free(self) -> T {
-        self.0
+    pub fn free(self) -> (T, Pins) {
+        let sck = self.0.psel.sck.read();
+        let mosi = self.0.psel.mosi.read();
+        let miso = self.0.psel.miso.read();
+        (
+            self.0,
+            Pins {
+                sck: unsafe { Pin::from_psel_bits(sck.bits()) },
+                mosi: if mosi.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(mosi.bits()) })
+                } else {
+                    None
+                },
+                miso: if miso.connect().bit_is_set() {
+                    Some(unsafe { Pin::from_psel_bits(miso.bits()) })
+                } else {
+                    None
+                },
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -409,6 +409,10 @@ where
         let cs = self.spis.psel.csn.read();
         let copi = self.spis.psel.mosi.read();
         let cipo = self.spis.psel.miso.read();
+        self.spis.psel.sck.reset();
+        self.spis.psel.csn.reset();
+        self.spis.psel.mosi.reset();
+        self.spis.psel.miso.reset();
         (
             self.spis,
             Pins {

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -235,8 +235,16 @@ where
     }
 
     /// Return the raw interface to the underlying TWI peripheral.
-    pub fn free(self) -> T {
-        self.0
+    pub fn free(self) -> (T, Pins) {
+        let scl = self.0.pselscl.read();
+        let sda = self.0.pselsda.read();
+        (
+            self.0,
+            Pins {
+                scl: unsafe { Pin::from_psel_bits(scl.bits()) },
+                sda: unsafe { Pin::from_psel_bits(sda.bits()) },
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -238,6 +238,8 @@ where
     pub fn free(self) -> (T, Pins) {
         let scl = self.0.pselscl.read();
         let sda = self.0.pselsda.read();
+        self.0.pselscl.reset();
+        self.0.pselsda.reset();
         (
             self.0,
             Pins {

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -381,6 +381,8 @@ where
     pub fn free(self) -> (T, Pins) {
         let scl = self.0.psel.scl.read();
         let sda = self.0.psel.sda.read();
+        self.0.psel.scl.reset();
+        self.0.psel.sda.reset();
         (
             self.0,
             Pins {

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -378,8 +378,16 @@ where
     }
 
     /// Return the raw interface to the underlying TWIM peripheral.
-    pub fn free(self) -> T {
-        self.0
+    pub fn free(self) -> (T, Pins) {
+        let scl = self.0.psel.scl.read();
+        let sda = self.0.psel.sda.read();
+        (
+            self.0,
+            Pins {
+                scl: unsafe { Pin::from_psel_bits(scl.bits()) },
+                sda: unsafe { Pin::from_psel_bits(sda.bits()) },
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -450,8 +450,16 @@ where
     }
 
     /// Return the raw interface to the underlying TWIS peripheral.
-    pub fn free(self) -> T {
-        self.0
+    pub fn free(self) -> (T, Pins) {
+        let scl = self.0.psel.scl.read();
+        let sda = self.0.psel.sda.read();
+        (
+            self.0,
+            Pins {
+                scl: unsafe { Pin::from_psel_bits(scl.bits()) },
+                sda: unsafe { Pin::from_psel_bits(sda.bits()) },
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/twis.rs
+++ b/nrf-hal-common/src/twis.rs
@@ -453,6 +453,8 @@ where
     pub fn free(self) -> (T, Pins) {
         let scl = self.0.psel.scl.read();
         let sda = self.0.psel.sda.read();
+        self.0.psel.scl.reset();
+        self.0.psel.sda.reset();
         (
             self.0,
             Pins {

--- a/nrf-hal-common/src/uart.rs
+++ b/nrf-hal-common/src/uart.rs
@@ -70,8 +70,28 @@ where
     }
 
     /// Return the raw interface to the underlying UARTE peripheral.
-    pub fn free(self) -> T {
-        self.0
+    pub fn free(self) -> (T, Pins) {
+        let rxd = self.0.pselrxd.read();
+        let txd = self.0.pseltxd.read();
+        let cts = self.0.pselcts.read();
+        let rts = self.0.pselrts.read();
+        (
+            self.0,
+            Pins {
+                rxd: unsafe { Pin::from_psel_bits(rxd.bits()) },
+                txd: unsafe { Pin::from_psel_bits(txd.bits()) },
+                cts: if cts.bits() != 0xFFFFFFFF {
+                    Some(unsafe { Pin::from_psel_bits(cts.bits()) })
+                } else {
+                    None
+                },
+                rts: if rts.bits() != 0xFFFFFFFF {
+                    Some(unsafe { Pin::from_psel_bits(rts.bits()) })
+                } else {
+                    None
+                },
+            },
+        )
     }
 }
 

--- a/nrf-hal-common/src/uart.rs
+++ b/nrf-hal-common/src/uart.rs
@@ -75,6 +75,10 @@ where
         let txd = self.0.pseltxd.read();
         let cts = self.0.pselcts.read();
         let rts = self.0.pselrts.read();
+        self.0.pselrxd.reset(); // Reset pins
+        self.0.pseltxd.reset();
+        self.0.pselcts.reset();
+        self.0.pselrts.reset();
         (
             self.0,
             Pins {

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -287,6 +287,10 @@ where
         let txd = self.0.psel.txd.read();
         let cts = self.0.psel.cts.read();
         let rts = self.0.psel.rts.read();
+        self.0.psel.rxd.reset();
+        self.0.psel.txd.reset();
+        self.0.psel.cts.reset();
+        self.0.psel.rts.reset();
         (
             self.0,
             Pins {

--- a/nrf52840-hal-tests/tests/gpio-output-open-drain.rs
+++ b/nrf52840-hal-tests/tests/gpio-output-open-drain.rs
@@ -52,7 +52,7 @@ mod tests {
     }
 
     // with the current API we cannot test this w/o an _external_ pull-up
-    /* 
+    /*
     #[test]
     fn set_high_is_high(state: &mut State) {
         state.output_pin.set_high().unwrap();

--- a/nrf52840-hal-tests/tests/serial.rs
+++ b/nrf52840-hal-tests/tests/serial.rs
@@ -54,10 +54,7 @@ mod tests {
 
         let _uarte = Uarte::new(p.UARTE0, pins, Parity::EXCLUDED, Baudrate::BAUD9600);
 
-        State {
-            _uarte,
-            _timer,
-        }
+        State { _uarte, _timer }
     }
 
     // won't work because of how the `read` API work


### PR DESCRIPTION
Hi,

I unified so pins are returned the same for all peripherals.