### PR TITLE
Implement MultiwriteNorFlash for nRF52 boards that support it

### DIFF
--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -183,7 +183,7 @@ where
     }
 }
 
-// Only nRF52 boards have been checked. There 2 things to note:
+// Only nRF52 boards have been checked. There are 2 things to note:
 //
 // 1. The nRF52832 doesn't support 2 writes per word. Instead it supports 181 writes per block,
 // where a block is 128 words. So on average it's a bit less than 2 writes per word, and thus we

--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -183,6 +183,21 @@ where
     }
 }
 
+// Only nRF52 boards have been checked. There 2 things to note:
+//
+// 1. The nRF52832 doesn't support 2 writes per word. Instead it supports 181 writes per block,
+// where a block is 128 words. So on average it's a bit less than 2 writes per word, and thus we
+// can't implement MultiwriteNorFlash.
+//
+// 2. The nRF52820 supports 2 writes per word but doesn't have an associated feature.
+#[cfg(any(
+    feature = "52810",
+    feature = "52811",
+    feature = "52833",
+    feature = "52840",
+))]
+impl<T: Instance> embedded_storage::nor_flash::MultiwriteNorFlash for Nvmc<T> {}
+
 pub trait Instance: Deref<Target = nvmc::RegisterBlock> + sealed::Sealed {}
 
 impl Instance for NVMC {}


### PR DESCRIPTION
This PR implements `MultiwriteNorFlash` as suggested [here](https://github.com/nrf-rs/nrf-hal/issues/336#issuecomment-878684844).

I only listed nRF52 boards that support writing twice to the same word, because I'm not familiar with the other boards or crate features.