### PR TITLE
Improve Nvmc implementation of embedded-storage traits

### DIFF
--- a/examples/nvmc-demo/Cargo.toml
+++ b/examples/nvmc-demo/Cargo.toml
@@ -12,6 +12,7 @@ cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 embedded-storage = "0.2.0"
 rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
 [dependencies.embedded-hal]
 version = "0.2.3"

--- a/examples/nvmc-demo/memory.x
+++ b/examples/nvmc-demo/memory.x
@@ -2,8 +2,8 @@ MEMORY
 {
   /* NOTE 1 K = 1 KiB = 1024 bytes */
   FLASH : ORIGIN = 0x00000000, LENGTH = 1024K - 16K
-  /* We use 4 pages of 4 KiB each, so 16 KiB */
-  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 16K
+  /* We use 6 pages of 4 KiB each */
+  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 6 * 4K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 

--- a/examples/nvmc-demo/memory.x
+++ b/examples/nvmc-demo/memory.x
@@ -1,8 +1,9 @@
 MEMORY
 {
-  /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  FLASH : ORIGIN = 0x00000000, LENGTH = 1020K
-  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 4K /* 4K is the flash page size */
+  /* NOTE 1 K = 1 KiB = 1024 bytes */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 1024K - 16K
+  /* We use 4 pages of 4 KiB each, so 16 KiB */
+  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 16K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 

--- a/examples/nvmc-demo/memory.x
+++ b/examples/nvmc-demo/memory.x
@@ -1,12 +1,12 @@
 MEMORY
 {
   /* NOTE 1 K = 1 KiB = 1024 bytes */
-  FLASH : ORIGIN = 0x00000000, LENGTH = 1024K - 16K
-  /* We use 6 pages of 4 KiB each */
-  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 6 * 4K
+  FLASH : ORIGIN = 0x00000000, LENGTH = 1024K - NUM_PAGES * 4K
+  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = NUM_PAGES * 4K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
+NUM_PAGES = 6;
 _config = ORIGIN(CONFIG);
 
 /* This is where the call stack will be allocated. */

--- a/examples/nvmc-demo/src/main.rs
+++ b/examples/nvmc-demo/src/main.rs
@@ -14,13 +14,12 @@ use hal::pac::NVMC;
 use panic_probe as _;
 use rtt_target::{rprintln, rtt_init_print};
 
-// We use 4 pages to use non-zero offsets.
+const NUM_PAGES: usize = 6;
 const PAGE_SIZE: u32 = 4 * 1024;
 const LAST_PAGE: u32 = 3 * PAGE_SIZE;
-const CONFIG_SIZE: usize = 4 * PAGE_SIZE as usize / 4;
 extern "C" {
     #[link_name = "_config"]
-    static mut CONFIG: [u32; CONFIG_SIZE];
+    static mut CONFIG: [u8; NUM_PAGES * PAGE_SIZE as usize];
 }
 
 // To run this example:
@@ -88,9 +87,7 @@ fn read<const LENGTH: usize>(nvmc: &mut Nvmc<NVMC>, offset: u32) -> [u8; LENGTH]
 }
 
 unsafe fn direct_read<const LENGTH: usize>(offset: u32) -> [u8; LENGTH] {
-    let ptr = &CONFIG as *const u32 as *const u8;
-    let slice = core::slice::from_raw_parts(ptr, CONFIG_SIZE * 4);
-    slice[offset as usize..][..LENGTH].try_into().unwrap()
+    CONFIG[offset as usize..][..LENGTH].try_into().unwrap()
 }
 
 fn erase_if_needed(nvmc: &mut Nvmc<NVMC>, offset: u32) {

--- a/examples/nvmc-demo/src/main.rs
+++ b/examples/nvmc-demo/src/main.rs
@@ -6,18 +6,26 @@
 #[cfg(feature = "52840")]
 use nrf52840_hal as hal;
 
+use core::convert::TryInto;
 use embedded_storage::nor_flash::NorFlash;
 use embedded_storage::nor_flash::ReadNorFlash;
 use hal::nvmc::Nvmc;
+use hal::pac::NVMC;
+use panic_probe as _;
 use rtt_target::{rprintln, rtt_init_print};
 
-const CONFIG_SIZE: usize = 1024;
+// We use 4 pages to use non-zero offsets.
+const PAGE_SIZE: u32 = 4 * 1024;
+const LAST_PAGE: u32 = 3 * PAGE_SIZE;
+const CONFIG_SIZE: usize = 4 * PAGE_SIZE as usize / 4;
 extern "C" {
     #[link_name = "_config"]
     static mut CONFIG: [u32; CONFIG_SIZE];
 }
 
-// To run this: `cargo embed --features "52840" --target thumbv7em-none-eabihf`
+// To run this example:
+// cargo build --features=52840 --target=thumbv7em-none-eabi && \
+// probe-run --chip nRF52840_xxAA ../../target/thumbv7em-none-eabi/debug/nvmc-demo
 
 #[cortex_m_rt::entry]
 fn main() -> ! {
@@ -28,23 +36,79 @@ fn main() -> ! {
     #[cfg(feature = "52840")]
     let mut nvmc = Nvmc::new(p.NVMC, unsafe { &mut CONFIG });
 
-    assert!(nvmc.erase(0, CONFIG_SIZE as u32 * 4).is_ok());
-    let write_buf: [u8; 4] = [1, 2, 3, 4];
-    assert!(nvmc.write(0, &write_buf).is_ok());
-    let mut read_buf = [0u8; 2];
-    assert!(nvmc.read(0, &mut read_buf).is_ok());
-    assert_eq!(read_buf, write_buf[0..2]);
+    erase_if_needed(&mut nvmc, LAST_PAGE);
 
-    rprintln!("What was written to flash was read!");
+    let mut write_buf: [u8; 32] = [0; 32];
+    for (i, x) in write_buf.iter_mut().enumerate() {
+        *x = i as u8;
+    }
+    rprintln!("Writing at {:#x}: {:02x?}", LAST_PAGE, write_buf);
+    nvmc.write(LAST_PAGE, &write_buf).unwrap();
+
+    for i in 0..4 {
+        compare_read::<11>(&mut nvmc, LAST_PAGE + i);
+        compare_read::<10>(&mut nvmc, LAST_PAGE + i);
+        compare_read::<9>(&mut nvmc, LAST_PAGE + i + 4);
+        compare_read::<8>(&mut nvmc, LAST_PAGE + i + 4);
+        compare_read::<7>(&mut nvmc, LAST_PAGE + i + 8);
+        compare_read::<6>(&mut nvmc, LAST_PAGE + i + 8);
+        compare_read::<5>(&mut nvmc, LAST_PAGE + i + 16);
+        compare_read::<4>(&mut nvmc, LAST_PAGE + i + 16);
+        compare_read::<3>(&mut nvmc, LAST_PAGE + i + 20);
+        compare_read::<2>(&mut nvmc, LAST_PAGE + i + 20);
+        compare_read::<1>(&mut nvmc, LAST_PAGE + i + 24);
+    }
+
+    erase_if_needed(&mut nvmc, LAST_PAGE);
 
     loop {
         cortex_m::asm::wfe();
     }
 }
 
-#[panic_handler] // panicking behavior
-fn panic(_: &core::panic::PanicInfo) -> ! {
-    loop {
-        cortex_m::asm::bkpt();
+fn compare_read<const LENGTH: usize>(nvmc: &mut Nvmc<NVMC>, offset: u32) {
+    let actual = read::<LENGTH>(nvmc, offset);
+    let expected = unsafe { direct_read::<LENGTH>(offset) };
+    if actual == expected {
+        rprintln!("Read at {:#x}: {:02x?} as expected", offset, actual);
+    } else {
+        rprintln!(
+            "Error: Read at {:#x}: {:02x?} instead of {:02x?}",
+            offset,
+            actual,
+            expected,
+        );
     }
+}
+
+fn read<const LENGTH: usize>(nvmc: &mut Nvmc<NVMC>, offset: u32) -> [u8; LENGTH] {
+    let mut buf = [0; LENGTH];
+    nvmc.read(offset, &mut buf).unwrap();
+    buf
+}
+
+unsafe fn direct_read<const LENGTH: usize>(offset: u32) -> [u8; LENGTH] {
+    let ptr = &CONFIG as *const u32 as *const u8;
+    let slice = core::slice::from_raw_parts(ptr, CONFIG_SIZE * 4);
+    slice[offset as usize..][..LENGTH].try_into().unwrap()
+}
+
+fn erase_if_needed(nvmc: &mut Nvmc<NVMC>, offset: u32) {
+    let mut page = [0; PAGE_SIZE as usize];
+    nvmc.read(offset, &mut page).unwrap();
+    if page_is_erased(&page) {
+        return;
+    }
+    rprintln!("Erasing at {:#x}", offset);
+    nvmc.erase(offset, offset + PAGE_SIZE).unwrap();
+    nvmc.read(offset, &mut page).unwrap();
+    if page_is_erased(&page) {
+        rprintln!("The page was correctly erased.");
+    } else {
+        rprintln!("Error: The page was not correctly erased.");
+    }
+}
+
+fn page_is_erased(page: &[u8; PAGE_SIZE as usize]) -> bool {
+    page.iter().all(|&x| x == 0xff)
 }

--- a/examples/nvmc-demo/src/main.rs
+++ b/examples/nvmc-demo/src/main.rs
@@ -14,12 +14,12 @@ use hal::pac::NVMC;
 use panic_probe as _;
 use rtt_target::{rprintln, rtt_init_print};
 
-const NUM_PAGES: usize = 6;
+const NUM_PAGES: u32 = 6;
 const PAGE_SIZE: u32 = 4 * 1024;
-const LAST_PAGE: u32 = 3 * PAGE_SIZE;
+const LAST_PAGE: u32 = (NUM_PAGES - 1) * PAGE_SIZE;
 extern "C" {
     #[link_name = "_config"]
-    static mut CONFIG: [u8; NUM_PAGES * PAGE_SIZE as usize];
+    static mut CONFIG: [u8; (NUM_PAGES * PAGE_SIZE) as usize];
 }
 
 // To run this example:

--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -14,10 +14,14 @@ use crate::pac::NVMC_NS as NVMC;
 use core::convert::TryInto;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 
+type WORD = u32;
+const WORD_SIZE: usize = core::mem::size_of::<WORD>();
+const PAGE_SIZE: usize = 4 * 1024;
+
 /// Interface to an NVMC instance.
 pub struct Nvmc<T: Instance> {
     nvmc: T,
-    storage: &'static mut [u32],
+    storage: &'static mut [u8],
 }
 
 impl<T> Nvmc<T>
@@ -25,12 +29,16 @@ where
     T: Instance,
 {
     /// Takes ownership of the peripheral and storage area.
-    pub fn new(nvmc: T, storage: &'static mut [u32]) -> Nvmc<T> {
+    ///
+    /// The storage area must be page-aligned.
+    pub fn new(nvmc: T, storage: &'static mut [u8]) -> Nvmc<T> {
+        assert!(storage.as_ptr() as usize % PAGE_SIZE == 0);
+        assert!(storage.len() % PAGE_SIZE == 0);
         Self { nvmc, storage }
     }
 
     /// Consumes `self` and returns back the raw peripheral and associated storage.
-    pub fn free(self) -> (T, &'static mut [u32]) {
+    pub fn free(self) -> (T, &'static mut [u8]) {
         (self.nvmc, self.storage)
     }
 
@@ -68,27 +76,35 @@ where
 
     #[cfg(not(any(feature = "9160", feature = "5340-app")))]
     #[inline]
-    fn erase_page(&mut self, offset: usize) {
-        let bits = &mut (self.storage[offset as usize >> 2]) as *mut _ as u32;
+    fn erase_page(&mut self, page_offset: usize) {
+        let bits = &mut (self.storage[page_offset * PAGE_SIZE]) as *mut _ as u32;
         self.nvmc.erasepage().write(|w| unsafe { w.bits(bits) });
         self.wait_ready();
     }
 
     #[cfg(any(feature = "9160", feature = "5340-app"))]
     #[inline]
-    fn erase_page(&mut self, offset: usize) {
-        self.storage[offset as usize >> 2] = 0xffffffff;
+    fn erase_page(&mut self, page_offset: usize) {
+        self.direct_write_word(page_offset * PAGE_SIZE, 0xffffffff);
         self.wait_ready();
     }
 
     #[inline]
-    fn write_word(&mut self, offset: usize, word: u32) {
+    fn write_word(&mut self, word_offset: usize, word: u32) {
         #[cfg(not(any(feature = "9160", feature = "5340-app")))]
         self.wait_ready();
         #[cfg(any(feature = "9160", feature = "5340-app"))]
         self.wait_write_ready();
-        self.storage[offset] = word;
+        self.direct_write_word(word_offset, word);
         cortex_m::asm::dmb();
+    }
+
+    #[inline]
+    fn direct_write_word(&mut self, word_offset: usize, word: u32) {
+        let target: &mut [u8] = &mut self.storage[word_offset * WORD_SIZE..][..WORD_SIZE];
+        let target: &mut [u8; WORD_SIZE] = target.try_into().unwrap();
+        let target: &mut u32 = unsafe { core::mem::transmute(target) };
+        *target = word;
     }
 }
 
@@ -100,39 +116,18 @@ where
 
     const READ_SIZE: usize = 1;
 
-    fn read(&mut self, offset: u32, mut bytes: &mut [u8]) -> Result<(), Self::Error> {
-        let mut offset = offset as usize;
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let offset = offset as usize;
         if bytes.len() > self.capacity() || offset > self.capacity() - bytes.len() {
             return Err(NvmcError::OutOfBounds);
         }
         self.wait_ready();
-        if offset & 3 != 0 {
-            let word = self.storage[offset >> 2].to_ne_bytes();
-            let start = offset & 3;
-            let length = 4 - start;
-            if length > bytes.len() {
-                bytes.copy_from_slice(&word[start..start + bytes.len()]);
-                return Ok(());
-            }
-            bytes[..length].copy_from_slice(&word[start..]);
-            offset = offset + length;
-            bytes = &mut bytes[length..];
-        }
-        let mut word_offset = offset >> 2;
-        let mut chunks = bytes.chunks_exact_mut(4);
-        for bytes in &mut chunks {
-            bytes.copy_from_slice(&self.storage[word_offset].to_ne_bytes());
-            word_offset += 1;
-        }
-        let bytes = chunks.into_remainder();
-        if !bytes.is_empty() {
-            bytes.copy_from_slice(&self.storage[word_offset].to_ne_bytes()[..bytes.len()]);
-        }
+        bytes.copy_from_slice(&self.storage[offset..][..bytes.len()]);
         Ok(())
     }
 
     fn capacity(&self) -> usize {
-        self.storage.len() << 2
+        self.storage.len()
     }
 }
 
@@ -140,22 +135,22 @@ impl<T> NorFlash for Nvmc<T>
 where
     T: Instance,
 {
-    const WRITE_SIZE: usize = 4;
+    const WRITE_SIZE: usize = WORD_SIZE;
 
-    const ERASE_SIZE: usize = 4 * 1024;
+    const ERASE_SIZE: usize = PAGE_SIZE;
 
     fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
-        let from = from as usize;
-        let to = to as usize;
+        let (from, to) = (from as usize, to as usize);
         if from > to || to > self.capacity() {
             return Err(NvmcError::OutOfBounds);
         }
-        if from % Self::ERASE_SIZE != 0 || to % Self::ERASE_SIZE != 0 {
+        if from % PAGE_SIZE != 0 || to % PAGE_SIZE != 0 {
             return Err(NvmcError::Unaligned);
         }
+        let (page_from, page_to) = (from / PAGE_SIZE, to / PAGE_SIZE);
         self.enable_erase();
-        for offset in (from..to).step_by(Self::ERASE_SIZE) {
-            self.erase_page(offset);
+        for page_offset in page_from..page_to {
+            self.erase_page(page_offset);
         }
         self.enable_read();
         Ok(())
@@ -166,15 +161,13 @@ where
         if bytes.len() > self.capacity() || offset as usize > self.capacity() - bytes.len() {
             return Err(NvmcError::OutOfBounds);
         }
-        if offset % Self::WRITE_SIZE != 0 || bytes.len() % Self::WRITE_SIZE != 0 {
+        if offset % WORD_SIZE != 0 || bytes.len() % WORD_SIZE != 0 {
             return Err(NvmcError::Unaligned);
         }
+        let word_offset = offset / WORD_SIZE;
         self.enable_write();
-        let mut word_offset = offset >> 2;
-        for bytes in bytes.chunks_exact(4) {
-            // The unwrap is correct because chunks_exact always returns the correct size.
+        for (word_offset, bytes) in (word_offset..).zip(bytes.chunks_exact(WORD_SIZE)) {
             self.write_word(word_offset, u32::from_ne_bytes(bytes.try_into().unwrap()));
-            word_offset += 1;
         }
         self.enable_read();
         Ok(())

--- a/nrf52840-hal-tests/memory.x
+++ b/nrf52840-hal-tests/memory.x
@@ -1,11 +1,12 @@
 MEMORY
 {
-  /* NOTE 1 K = 1 KiBi = 1024 bytes */
-  FLASH : ORIGIN = 0x00000000, LENGTH = 1020K
-  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = 4K /* 4K is the flash page size */
+  /* NOTE 1 K = 1 KiB = 1024 bytes */
+  FLASH : ORIGIN = 0x00000000, LENGTH = 1024K - NUM_PAGES * 4K
+  CONFIG : ORIGIN = ORIGIN(FLASH) + LENGTH(FLASH), LENGTH = NUM_PAGES * 4K
   RAM : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
+NUM_PAGES = 6;
 _config = ORIGIN(CONFIG);
 
 /* This is where the call stack will be allocated. */

--- a/nrf52840-hal-tests/tests/nvmc.rs
+++ b/nrf52840-hal-tests/tests/nvmc.rs
@@ -8,10 +8,13 @@ use panic_probe as _;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use nrf52840_hal::{nvmc::Nvmc, pac};
 
-const CONFIG_SIZE: usize = 1024;
+const NUM_PAGES: u32 = 6; // must match memory.x
+const PAGE_SIZE: u32 = 4 * 1024;
+const LAST_PAGE: u32 = (NUM_PAGES - 1) * PAGE_SIZE;
+const CONFIG_SIZE: u32 = NUM_PAGES * PAGE_SIZE;
 extern "C" {
     #[link_name = "_config"]
-    static mut CONFIG: [u32; CONFIG_SIZE];
+    static mut CONFIG: [u8; CONFIG_SIZE as usize];
 }
 
 struct State {
@@ -35,66 +38,65 @@ mod tests {
 
     #[test]
     fn check_capacity(state: &mut State) {
-        assert_eq!(state.nvmc.capacity(), CONFIG_SIZE * 4);
+        assert_eq!(state.nvmc.capacity(), CONFIG_SIZE as usize);
     }
 
     #[test]
-    fn read_unaligned(state: &mut State) {
-        let mut buf = [0u8; 1];
-        assert!(state.nvmc.read(1, &mut buf).is_err());
+    fn read_outofbounds(state: &mut State) {
+        assert!(state.nvmc.read(CONFIG_SIZE, &mut [0]).is_err());
+        assert!(state.nvmc.read(CONFIG_SIZE - 1, &mut [0, 0]).is_err());
     }
 
     #[test]
-    fn read_beyond_buffer(state: &mut State) {
-        let mut buf = [0u8; CONFIG_SIZE * 4 + 1];
-        assert!(state.nvmc.read(0, &mut buf).is_err());
+    fn erase_unaligned(state: &mut State) {
+        assert!(state.nvmc.erase(LAST_PAGE + 1, PAGE_SIZE).is_err());
+        assert!(state.nvmc.erase(LAST_PAGE, PAGE_SIZE + 1).is_err());
     }
 
     #[test]
-    fn erase_unaligned_from(state: &mut State) {
-        assert!(state.nvmc.erase(1, 4096).is_err());
-    }
-
-    #[test]
-    fn erase_unaligned_to(state: &mut State) {
-        assert!(state.nvmc.erase(0, 4097).is_err());
+    fn erase_outofbounds(state: &mut State) {
+        assert!(state
+            .nvmc
+            .erase(CONFIG_SIZE, CONFIG_SIZE + PAGE_SIZE)
+            .is_err());
+        assert!(state
+            .nvmc
+            .erase(LAST_PAGE, LAST_PAGE + 2 * PAGE_SIZE)
+            .is_err());
     }
 
     #[test]
     fn write_unaligned(state: &mut State) {
-        let buf = [0u8; 1];
-        assert!(state.nvmc.write(1, &buf).is_err());
+        let buf = [0u8; 4];
+        assert!(state.nvmc.write(LAST_PAGE + 1, &buf).is_err());
+        assert!(state.nvmc.write(LAST_PAGE, &buf[..1]).is_err());
     }
 
     #[test]
     fn read_write_and_then_read(state: &mut State) {
-        assert!(state.nvmc.erase(0, CONFIG_SIZE as u32 * 4).is_ok());
-        let mut read_buf = [0u8; 1];
-        assert!(state.nvmc.read(0, &mut read_buf).is_ok());
+        assert!(state.nvmc.erase(LAST_PAGE, CONFIG_SIZE).is_ok());
+        let mut read_buf = [0];
+        assert!(state.nvmc.read(LAST_PAGE, &mut read_buf).is_ok());
         assert_eq!(read_buf[0], 0xff);
-        let write_buf = [1u8; 4];
-        assert!(state.nvmc.write(0, &write_buf).is_ok());
-        assert!(state.nvmc.read(0, &mut read_buf).is_ok());
-        assert_eq!(read_buf[0], 0x1);
+        let write_buf = [1, 2, 3, 4];
+        assert!(state.nvmc.write(LAST_PAGE, &write_buf).is_ok());
+        assert!(state.nvmc.read(LAST_PAGE, &mut read_buf).is_ok());
+        assert_eq!(read_buf[0], 1);
     }
 
     #[test]
     fn read_what_is_written(state: &mut State) {
-        assert!(state.nvmc.erase(0, CONFIG_SIZE as u32 * 4).is_ok());
+        assert!(state.nvmc.erase(LAST_PAGE, CONFIG_SIZE).is_ok());
         let write_buf: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
-        assert!(state.nvmc.write(0, &write_buf).is_ok());
+        assert!(state.nvmc.write(LAST_PAGE, &write_buf).is_ok());
         let mut read_buf = [0u8; 8];
-        assert!(state.nvmc.read(0, &mut read_buf).is_ok());
+        assert!(state.nvmc.read(LAST_PAGE, &mut read_buf).is_ok());
         assert_eq!(read_buf, write_buf);
-    }
-
-    #[test]
-    fn partially_read_what_is_written(state: &mut State) {
-        assert!(state.nvmc.erase(0, CONFIG_SIZE as u32 * 4).is_ok());
-        let write_buf: [u8; 4] = [1, 2, 3, 4];
-        assert!(state.nvmc.write(0, &write_buf).is_ok());
-        let mut read_buf = [0u8; 2];
-        assert!(state.nvmc.read(0, &mut read_buf).is_ok());
-        assert_eq!(read_buf, write_buf[0..2]);
+        let mut partial_read_buf = [0u8; 4];
+        assert!(state
+            .nvmc
+            .read(LAST_PAGE + 2, &mut partial_read_buf)
+            .is_ok());
+        assert_eq!(partial_read_buf, write_buf[2..][..4]);
     }
 }


### PR DESCRIPTION
This PR opens a design discussion regarding the Nvmc API and implementation.

It contains the following 3 commits:
1. Modify the example to surface some of the following issues:
    - Bug: [`new`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L28) doesn't check that the storage is well-aligned.
    - Bug: [`read`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L112) confuses offsets in the storage and offsets in the output buffer.
    - Bug: Many arithmetic overflows like [here](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L106)
    - Bug: [Off-by-one error](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L105) when the `read` output buffer is word-aligned.
    - Bug: [`read`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L112) reads big-endian words regardless of the architecture.
    - Bug: [`erase`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L155) doesn't check that the input is within bounds.
    - Bug: [`erase`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L158) divides by 4 twice (other time is in [`erase_page`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L71)).
    - Bug: [`write`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L169) doesn't check that the input is within bounds.
    - Bug: [`write`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L172) confuses offsets in the storage and offsets in the input buffer.
    - Bug: [`write`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L172) writes big-endian words regardless of the architecture.
    - Error-prone: `read` is very complicated and seems to have other bugs.
    - Not ideal: [`READ_SIZE`](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L100) is 4 instead of 1, which is unnecessarily constraining (at least for nRF52840).
    - Not ideal: The [storage slice](https://github.com/nrf-rs/nrf-hal/blob/bcd5c5da6e5087b7efd943806ec599d42b5e2c3f/nrf-hal-common/src/nvmc.rs#L19) has type `[u32]` instead of `[u8]`, which optimizes for writes instead of reads.
2. Fix most of the issues. This is a breaking change because it changes the `READ_SIZE` from 4 to 1 and adds `NvmcError::OutOfBounds`. But those changes seem needed.
3. Fix the remaining issues. This is a more controversial breaking change. It simplifies the implementation a bit more but is not needed (although it could improve the read performance significantly which is probably the most common operation).
