### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@
 
 - Unified how pins are are returned in `free` calls ([#372]).
 - Improvements to the NVMC driver ([#374]).
+- Updated `embedded-dma`, `embedded-storage`, and PACs ([#379]).
 
 [#372]: https://github.com/nrf-rs/nrf-hal/pull/372
 [#373]: https://github.com/nrf-rs/nrf-hal/pull/373
 [#374]: https://github.com/nrf-rs/nrf-hal/pull/374
 [#376]: https://github.com/nrf-rs/nrf-hal/pull/376
+[#379]: https://github.com/nrf-rs/nrf-hal/pull/379
 
 ## [0.14.1]
 

--- a/examples/blinky-button-demo/Cargo.toml
+++ b/examples/blinky-button-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52832-hal = { features = ["rt"], path = "../../nrf52832-hal" }
 
 [dependencies.embedded-hal]

--- a/examples/ccm-demo/Cargo.toml
+++ b/examples/ccm-demo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 rand_core = "0.6.3"
 
 nrf52810-hal = { path = "../../nrf52810-hal", features = ["rt"], optional = true }

--- a/examples/comp-demo/Cargo.toml
+++ b/examples/comp-demo/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/comp-demo/src/main.rs
+++ b/examples/comp-demo/src/main.rs
@@ -1,33 +1,31 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::OutputPin;
-use {
-    core::{
-        panic::PanicInfo,
-        sync::atomic::{compiler_fence, Ordering},
-    },
-    hal::{
-        comp::*,
-        gpio::{Level, Output, Pin, PushPull},
-    },
-    nrf52840_hal as hal,
-    rtt_target::{rprintln, rtt_init_print},
-};
+use {core::panic::PanicInfo, rtt_target::rprintln};
 
-#[rtic::app(device = crate::hal::pac, peripherals = true)]
-const APP: () = {
-    struct Resources {
+#[rtic::app(device = nrf52840_hal::pac, peripherals = true)]
+mod app {
+    use embedded_hal::digital::v2::OutputPin;
+    use nrf52840_hal::clocks::Clocks;
+    use nrf52840_hal::comp::*;
+    use nrf52840_hal::gpio::{self, Level, Output, Pin, PushPull};
+    use rtt_target::{rprintln, rtt_init_print};
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
         comp: Comp,
         led1: Pin<Output<PushPull>>,
     }
 
     #[init]
-    fn init(ctx: init::Context) -> init::LateResources {
-        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let _clocks = Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
         rtt_init_print!();
 
-        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+        let p0 = gpio::p0::Parts::new(ctx.device.P0);
         let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
         let in_pin = p0.p0_30.into_floating_input();
         let ref_pin = p0.p0_31.into_floating_input();
@@ -38,31 +36,29 @@ const APP: () = {
             .enable_interrupt(Transition::Cross)
             .enable();
 
-        init::LateResources { comp, led1 }
+        (Shared {}, Local { comp, led1 }, init::Monotonics())
     }
 
-    #[task(binds = COMP_LPCOMP, resources = [comp, led1])]
+    #[task(binds = COMP_LPCOMP, local = [comp, led1])]
     fn on_comp(ctx: on_comp::Context) {
-        ctx.resources.comp.reset_event(Transition::Cross);
-        match ctx.resources.comp.read() {
+        ctx.local.comp.reset_event(Transition::Cross);
+        match ctx.local.comp.read() {
             CompResult::Above => {
                 rprintln!("Vin > Vref");
-                ctx.resources.led1.set_low().ok();
+                ctx.local.led1.set_low().ok();
             }
             CompResult::Below => {
                 rprintln!("Vin < Vref");
-                ctx.resources.led1.set_high().ok();
+                ctx.local.led1.set_high().ok();
             }
         }
     }
-};
+}
 
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
     rprintln!("{}", info);
-    loop {
-        compiler_fence(Ordering::SeqCst);
-    }
+    loop {}
 }

--- a/examples/gpiote-demo/Cargo.toml
+++ b/examples/gpiote-demo/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
+systick-monotonic = "1.0.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/i2s-controller-demo/Cargo.toml
+++ b/examples/i2s-controller-demo/Cargo.toml
@@ -10,10 +10,11 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
+systick-monotonic = "1.0.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
-heapless = "0.5.5"
+heapless = "0.7.10"
 small_morse = "0.1.0"
 
 [dependencies.embedded-hal]

--- a/examples/i2s-controller-demo/src/main.rs
+++ b/examples/i2s-controller-demo/src/main.rs
@@ -5,44 +5,44 @@
 // Generates Morse code audio signals for text from UART, playing back over I2S
 // Tested with nRF52840-DK and a UDA1334a DAC
 
-use embedded_hal::digital::v2::{InputPin, OutputPin};
-use heapless::{
-    consts::*,
-    spsc::{Consumer, Producer, Queue},
-};
-use small_morse::{encode, State};
-use {
-    core::{
-        panic::PanicInfo,
-        sync::atomic::{compiler_fence, Ordering},
-    },
-    hal::{
-        gpio::{Input, Level, Output, Pin, PullUp, PushPull},
-        gpiote::*,
-        i2s::{self, *},
-        pac::{TIMER0, UARTE0},
-        timer::Timer,
-        uarte::{self, *},
-    },
-    nrf52840_hal as hal,
-    rtic::cyccnt::U32Ext,
-    rtt_target::{rprintln, rtt_init_print},
-};
+use {core::panic::PanicInfo, nrf52840_hal as hal, rtt_target::rprintln};
 
 #[repr(align(4))]
-struct Aligned<T: ?Sized>(T);
+pub struct Aligned<T: ?Sized>(T);
 
-#[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
-const APP: () = {
-    struct Resources {
+#[rtic::app(device = crate::hal::pac, peripherals = true, dispatchers = [SWI0_EGU0, SWI1_EGU1])]
+mod app {
+    use crate::{hal, triangle_wave, Aligned};
+    use embedded_hal::digital::v2::{InputPin, OutputPin};
+    use heapless::spsc::{Consumer, Producer, Queue};
+    use small_morse::{encode, State};
+    use systick_monotonic::*;
+    use {
+        hal::{
+            gpio::{Input, Level, Output, Pin, PullUp, PushPull},
+            gpiote::*,
+            i2s::{self, *},
+            pac::{TIMER0, UARTE0},
+            timer::Timer,
+            uarte::{self, *},
+        },
+        rtt_target::{rprintln, rtt_init_print},
+    };
+
+    #[monotonic(binds = SysTick, default = true)]
+    type Mono = Systick<1_000_000>;
+
+    #[shared]
+    struct Shared {
+        speed: u32,
+    }
+
+    #[local]
+    struct Local {
         signal_buf: &'static [i16; 32],
         mute_buf: &'static [i16; 32],
-        #[init(None)]
-        queue: Option<Queue<State, U256>>,
-        producer: Producer<'static, State, U256>,
-        consumer: Consumer<'static, State, U256>,
-        #[init(5_000_000)]
-        speed: u32,
+        producer: Producer<'static, State, 257>,
+        consumer: Consumer<'static, State, 257>,
         uarte: Uarte<UARTE0>,
         uarte_timer: Timer<TIMER0>,
         gpiote: Gpiote,
@@ -52,17 +52,21 @@ const APP: () = {
         transfer: Option<Transfer<&'static [i16; 32]>>,
     }
 
-    #[init(resources = [queue], spawn = [tick])]
-    fn init(mut ctx: init::Context) -> init::LateResources {
+    #[init(local = [
         // The I2S buffer address must be 4 byte aligned.
-        static mut MUTE_BUF: Aligned<[i16; 32]> = Aligned([0i16; 32]);
-        static mut SIGNAL_BUF: Aligned<[i16; 32]> = Aligned([0i16; 32]);
+        static_mute_buf: Aligned<[i16; 32]> = Aligned([0i16; 32]),
+        static_signal_buf: Aligned<[i16; 32]> = Aligned([0i16; 32]),
+        queue: Option<Queue<State, 257>> = None,
+    ])]
+    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
+        let signal_buf = ctx.local.static_signal_buf;
+        let mute_buf = ctx.local.static_mute_buf;
 
         // Fill signal buffer with triangle waveform, 2 channels interleaved
-        let len = SIGNAL_BUF.0.len() / 2;
+        let len = signal_buf.0.len() / 2;
         for x in 0..len {
-            SIGNAL_BUF.0[2 * x] = triangle_wave(x as i32, len, 2048, 0, 1) as i16;
-            SIGNAL_BUF.0[2 * x + 1] = triangle_wave(x as i32, len, 2048, 0, 1) as i16;
+            signal_buf.0[2 * x] = triangle_wave(x as i32, len, 2048, 0, 1) as i16;
+            signal_buf.0[2 * x + 1] = triangle_wave(x as i32, len, 2048, 0, 1) as i16;
         }
 
         let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
@@ -107,37 +111,41 @@ const APP: () = {
             Baudrate::BAUD115200,
         );
 
-        *ctx.resources.queue = Some(Queue::new());
-        let (producer, consumer) = ctx.resources.queue.as_mut().unwrap().split();
+        *ctx.local.queue = Some(Queue::new());
+        let (producer, consumer) = ctx.local.queue.as_mut().unwrap().split();
+
+        let mono = Mono::new(ctx.core.SYST, 64_000_000);
 
         rprintln!("Morse code generator");
         rprintln!("Send me text over UART @ 115_200 baud");
         rprintln!("Press button 1 to slow down or button 2 to speed up");
 
-        ctx.spawn.tick().ok();
+        tick::spawn().ok();
 
-        init::LateResources {
-            producer,
-            consumer,
-            gpiote,
-            btn1,
-            btn2,
-            led: p0.p0_13.into_push_pull_output(Level::High).degrade(),
-            uarte,
-            uarte_timer: Timer::new(ctx.device.TIMER0),
-            transfer: i2s.tx(&MUTE_BUF.0).ok(),
-            signal_buf: &SIGNAL_BUF.0,
-            mute_buf: &MUTE_BUF.0,
-        }
+        (
+            Shared { speed: 5_000_000 },
+            Local {
+                producer,
+                consumer,
+                gpiote,
+                btn1,
+                btn2,
+                led: p0.p0_13.into_push_pull_output(Level::High).degrade(),
+                uarte,
+                uarte_timer: Timer::new(ctx.device.TIMER0),
+                transfer: i2s.tx(&mute_buf.0).ok(),
+                signal_buf: &signal_buf.0,
+                mute_buf: &mute_buf.0,
+            },
+            init::Monotonics(mono),
+        )
     }
 
-    #[idle(resources=[uarte, uarte_timer, producer])]
+    #[idle(local = [uarte, uarte_timer, producer])]
     fn idle(ctx: idle::Context) -> ! {
-        let idle::Resources {
-            uarte,
-            uarte_timer,
-            producer,
-        } = ctx.resources;
+        let uarte = ctx.local.uarte;
+        let uarte_timer = ctx.local.uarte_timer;
+        let producer = ctx.local.producer;
         let uarte_rx_buf = &mut [0u8; 64][..];
         loop {
             match uarte.read_timeout(uarte_rx_buf, uarte_timer, 100_000) {
@@ -166,49 +174,43 @@ const APP: () = {
         }
     }
 
-    #[task(resources = [consumer, transfer, signal_buf, mute_buf, led, speed], schedule = [tick])]
-    fn tick(ctx: tick::Context) {
-        let (_buf, i2s) = ctx.resources.transfer.take().unwrap().wait();
-        match ctx.resources.consumer.dequeue() {
+    #[task(local = [consumer, transfer, signal_buf, mute_buf, led], shared = [speed])]
+    fn tick(mut ctx: tick::Context) {
+        let (_buf, i2s) = ctx.local.transfer.take().unwrap().wait();
+        match ctx.local.consumer.dequeue() {
             Some(State::On) => {
                 // Move TX pointer to signal buffer (sound ON)
-                *ctx.resources.transfer = i2s.tx(*ctx.resources.signal_buf).ok();
-                ctx.resources.led.set_low().ok();
+                *ctx.local.transfer = i2s.tx(*ctx.local.signal_buf).ok();
+                ctx.local.led.set_low().ok();
             }
             _ => {
                 // Move TX pointer to silent buffer (sound OFF)
-                *ctx.resources.transfer = i2s.tx(*ctx.resources.mute_buf).ok();
-                ctx.resources.led.set_high().ok();
+                *ctx.local.transfer = i2s.tx(*ctx.local.mute_buf).ok();
+                ctx.local.led.set_high().ok();
             }
         }
-        ctx.schedule
-            .tick(ctx.scheduled + ctx.resources.speed.cycles())
-            .ok();
+        let speed: u64 = ctx.shared.speed.lock(|speed| *speed).into();
+        tick::spawn_after(speed.micros()).ok();
     }
 
-    #[task(binds = GPIOTE, resources = [gpiote, speed], schedule = [debounce])]
+    #[task(binds = GPIOTE, local = [gpiote])]
     fn on_gpiote(ctx: on_gpiote::Context) {
-        ctx.resources.gpiote.reset_events();
-        ctx.schedule.debounce(ctx.start + 3_000_000.cycles()).ok();
+        ctx.local.gpiote.reset_events();
+        debounce::spawn_after(50.millis()).ok();
     }
 
-    #[task(resources = [btn1, btn2, speed])]
-    fn debounce(ctx: debounce::Context) {
-        if ctx.resources.btn1.is_low().unwrap() {
+    #[task(local = [btn1, btn2], shared = [speed])]
+    fn debounce(mut ctx: debounce::Context) {
+        if ctx.local.btn1.is_low().unwrap() {
             rprintln!("Go slower");
-            *ctx.resources.speed += 600_000;
+            ctx.shared.speed.lock(|speed| *speed += 600_000);
         }
-        if ctx.resources.btn2.is_low().unwrap() {
+        if ctx.local.btn2.is_low().unwrap() {
             rprintln!("Go faster");
-            *ctx.resources.speed -= 600_000;
+            ctx.shared.speed.lock(|speed| *speed -= 600_000);
         }
     }
-
-    extern "C" {
-        fn SWI0_EGU0();
-        fn SWI1_EGU1();
-    }
-};
+}
 
 fn triangle_wave(x: i32, length: usize, amplitude: i32, phase: i32, periods: i32) -> i32 {
     let length = length as i32;
@@ -225,7 +227,5 @@ fn triangle_wave(x: i32, length: usize, amplitude: i32, phase: i32, periods: i32
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
     rprintln!("{}", info);
-    loop {
-        compiler_fence(Ordering::SeqCst);
-    }
+    loop {}
 }

--- a/examples/i2s-peripheral-demo/Cargo.toml
+++ b/examples/i2s-peripheral-demo/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/lpcomp-demo/Cargo.toml
+++ b/examples/lpcomp-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/nvmc-demo/Cargo.toml
+++ b/examples/nvmc-demo/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-embedded-storage = "0.2.0"
+embedded-storage = "0.3.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 

--- a/examples/nvmc-demo/Cargo.toml
+++ b/examples/nvmc-demo/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
 embedded-storage = "0.2.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 panic-probe = { version = "0.3.0", features = ["print-rtt"] }
 
 [dependencies.embedded-hal]

--- a/examples/ppi-demo/Cargo.toml
+++ b/examples/ppi-demo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 nrf52810-hal = { path = "../../nrf52810-hal", features = ["rt"], optional = true }
 nrf52811-hal = { path = "../../nrf52811-hal", features = ["rt"], optional = true }

--- a/examples/pwm-blinky-demo/Cargo.toml
+++ b/examples/pwm-blinky-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nb = "1.0.0"
 
 [dependencies.embedded-hal]

--- a/examples/pwm-demo/Cargo.toml
+++ b/examples/pwm-demo/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
+systick-monotonic = "1.0.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 [dependencies.embedded-hal]
@@ -19,7 +20,3 @@ features = ["unproven"]
 [dependencies.nrf52840-hal]
 features = ["rt"]
 path = "../../nrf52840-hal"
-optional = true
-
-[features]
-52840 = ["nrf52840-hal"]

--- a/examples/qdec-demo/Cargo.toml
+++ b/examples/qdec-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/rtc-demo/Cargo.toml
+++ b/examples/rtc-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-rtt-target = {version = "0.2.0", features = ["cortex-m"] }
+rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 
 [dependencies.embedded-hal]

--- a/examples/rtic-demo/Cargo.toml
+++ b/examples/rtic-demo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-cortex-m-rtic = "0.5.9"
+cortex-m-rtic = "1.0.0"
 panic-semihosting = "0.5.3"
 cortex-m-semihosting = "0.3.5"
 

--- a/examples/rtic-demo/src/main.rs
+++ b/examples/rtic-demo/src/main.rs
@@ -4,7 +4,6 @@
 #[allow(unused_imports)]
 use panic_semihosting;
 
-use cortex_m_semihosting::{debug, hprintln};
 use rtic::app;
 
 #[cfg(feature = "51")]
@@ -23,10 +22,20 @@ use nrf52832_hal as hal;
 use nrf52840_hal as hal;
 
 #[app(device = crate::hal::pac)]
-const APP: () = {
+mod app {
+    use cortex_m_semihosting::{debug, hprintln};
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {}
+
     #[init]
-    fn init(_: init::Context) {
+    fn init(_: init::Context) -> (Shared, Local, init::Monotonics) {
         hprintln!("init").unwrap();
+
+        (Shared {}, Local {}, init::Monotonics())
     }
 
     #[idle]
@@ -35,8 +44,6 @@ const APP: () = {
 
         debug::exit(debug::EXIT_SUCCESS);
 
-        loop {
-            continue;
-        }
+        loop {}
     }
-};
+}

--- a/examples/spi-demo/Cargo.toml
+++ b/examples/spi-demo/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 [dependencies]
 cortex-m-rt = "0.7.0"
 panic-halt = "0.2.0"
-embedded-hal-spy = "0.0.3"
+embedded-hal-spy = "0.0.5"
 
 [dependencies.embedded-hal]
 features = ["unproven"]
@@ -18,10 +18,6 @@ version = "0.2"
 path = "../../nrf52832-hal"
 optional = true
 
-[dependencies.nrf52832-pac]
-version = "0.9.0"
-optional = true
-
 [features]
-52832 = ["nrf52832-hal", "nrf52832-pac"]
+52832 = ["nrf52832-hal"]
 default = ["52832"]

--- a/examples/spis-demo/Cargo.toml
+++ b/examples/spis-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/twim-demo/Cargo.toml
+++ b/examples/twim-demo/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
+systick-monotonic = "1.0.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/twim-demo/src/main.rs
+++ b/examples/twim-demo/src/main.rs
@@ -1,30 +1,35 @@
 #![no_std]
 #![no_main]
 
-#[allow(unused_imports)]
-use embedded_hal::blocking::i2c::{Read, Write};
-use embedded_hal::digital::v2::InputPin;
-use {
-    core::{
-        panic::PanicInfo,
-        sync::atomic::{compiler_fence, Ordering},
-    },
-    hal::{
-        gpio::{p0::Parts, Input, Pin, PullUp},
-        gpiote::Gpiote,
-        pac::TWIM0,
-        twim::*,
-    },
-    nrf52840_hal as hal,
-    rtic::cyccnt::U32Ext,
-    rtt_target::{rprintln, rtt_init_print},
-};
+use {core::panic::PanicInfo, nrf52840_hal as hal, rtt_target::rprintln};
 
-#[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
-const APP: () = {
-    struct Resources {
-        twim: Twim<TWIM0>,
+#[rtic::app(device = crate::hal::pac, peripherals = true, dispatchers = [SWI0_EGU0])]
+mod app {
+    use embedded_hal::digital::v2::InputPin;
+    use systick_monotonic::*;
+    use {
+        hal::{
+            gpio::{p0::Parts, Input, Pin, PullUp},
+            gpiote::Gpiote,
+            pac::TWIM0,
+            twim::*,
+        },
+        nrf52840_hal as hal,
+        rtt_target::{rprintln, rtt_init_print},
+    };
+
+    #[monotonic(binds = SysTick, default = true)]
+    type Mono = Systick<1_000_000>;
+
+    #[shared]
+    struct Shared {
+        #[lock_free]
         gpiote: Gpiote,
+    }
+
+    #[local]
+    struct Local {
+        twim: Twim<TWIM0>,
         btn1: Pin<Input<PullUp>>,
         btn2: Pin<Input<PullUp>>,
         btn3: Pin<Input<PullUp>>,
@@ -32,7 +37,7 @@ const APP: () = {
     }
 
     #[init]
-    fn init(mut ctx: init::Context) -> init::LateResources {
+    fn init(mut ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
         ctx.core.DCB.enable_trace();
         ctx.core.DWT.enable_cycle_counter();
@@ -55,14 +60,18 @@ const APP: () = {
 
         let twim = Twim::new(ctx.device.TWIM0, Pins { scl, sda }, Frequency::K100);
 
-        init::LateResources {
-            twim,
-            gpiote,
-            btn1,
-            btn2,
-            btn3,
-            btn4,
-        }
+        let mono = Mono::new(ctx.core.SYST, 64_000_000);
+        (
+            Shared { gpiote },
+            Local {
+                twim,
+                btn1,
+                btn2,
+                btn3,
+                btn4,
+            },
+            init::Monotonics(mono),
+        )
     }
 
     #[idle]
@@ -76,52 +85,46 @@ const APP: () = {
         }
     }
 
-    #[task(binds = GPIOTE, resources = [gpiote], schedule = [debounce])]
+    #[task(binds = GPIOTE, shared = [gpiote])]
     fn on_gpiote(ctx: on_gpiote::Context) {
-        ctx.resources.gpiote.reset_events();
-        ctx.schedule.debounce(ctx.start + 3_000_000.cycles()).ok();
+        ctx.shared.gpiote.reset_events();
+        debounce::spawn_after(50.millis()).ok();
     }
 
-    #[task(resources = [twim, gpiote, btn1, btn2, btn3, btn4])]
+    #[task(shared = [gpiote], local = [twim, btn1, btn2, btn3, btn4])]
     fn debounce(ctx: debounce::Context) {
-        let twim = ctx.resources.twim;
-        if ctx.resources.btn1.is_low().unwrap() {
+        let twim = ctx.local.twim;
+        if ctx.local.btn1.is_low().unwrap() {
             rprintln!("\nREAD from address 0x1A");
             let rx_buf = &mut [0; 8][..];
             let res = twim.read(0x1A, rx_buf);
             rprintln!("Result: {:?}\n{:?}", res, rx_buf);
         }
-        if ctx.resources.btn2.is_low().unwrap() {
+        if ctx.local.btn2.is_low().unwrap() {
             rprintln!("\nWRITE to address 0x1A");
             let tx_buf = [1, 2, 3, 4, 5, 6, 7, 8];
             let res = twim.write(0x1A, &tx_buf[..]);
             rprintln!("Result: {:?}\n{:?}", res, tx_buf);
         }
-        if ctx.resources.btn3.is_low().unwrap() {
+        if ctx.local.btn3.is_low().unwrap() {
             rprintln!("\nREAD from address 0x1B");
             let rx_buf = &mut [0; 4][..];
             let res = twim.read(0x1B, rx_buf);
             rprintln!("Result: {:?}\n{:?}", res, rx_buf);
         }
-        if ctx.resources.btn4.is_low().unwrap() {
+        if ctx.local.btn4.is_low().unwrap() {
             rprintln!("\nWRITE to address 0x1B");
             let tx_buf = [9, 10, 11, 12];
             let res = twim.write(0x1B, &tx_buf[..]);
             rprintln!("Result: {:?}\n{:?}", res, tx_buf);
         }
     }
-
-    extern "C" {
-        fn SWI0_EGU0();
-    }
-};
+}
 
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
     rprintln!("{}", info);
-    loop {
-        compiler_fence(Ordering::SeqCst);
-    }
+    loop {}
 }

--- a/examples/twis-demo/Cargo.toml
+++ b/examples/twis-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/twis-demo/src/main.rs
+++ b/examples/twis-demo/src/main.rs
@@ -1,39 +1,37 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::OutputPin;
-use {
-    core::{
-        panic::PanicInfo,
-        sync::atomic::{compiler_fence, Ordering},
-    },
-    hal::{
-        gpio::{p0::Parts, Level, Output, Pin, PushPull},
-        pac::TWIS0,
-        twis::*,
-    },
-    nrf52840_hal as hal,
-    rtt_target::{rprintln, rtt_init_print},
-};
-
-const ADDR0: u8 = 0x1A;
-const ADDR1: u8 = 0x1B;
-const BUF0_SZ: usize = 8;
-const BUF1_SZ: usize = 4;
+use {core::panic::PanicInfo, nrf52840_hal as hal, rtt_target::rprintln};
 
 #[rtic::app(device = crate::hal::pac, peripherals = true)]
-const APP: () = {
-    struct Resources {
+mod app {
+    use embedded_hal::digital::v2::OutputPin;
+    use {
+        hal::{
+            gpio::{p0::Parts, Level, Output, Pin, PushPull},
+            pac::TWIS0,
+            twis::*,
+        },
+        nrf52840_hal as hal,
+        rtt_target::{rprintln, rtt_init_print},
+    };
+
+    const ADDR0: u8 = 0x1A;
+    const ADDR1: u8 = 0x1B;
+    const BUF0_SZ: usize = 8;
+    const BUF1_SZ: usize = 4;
+
+    #[shared]
+    struct Shared {}
+
+    #[local]
+    struct Local {
         twis: Twis<TWIS0>,
-        #[init([0; BUF0_SZ])]
-        buffer0: [u8; BUF0_SZ],
-        #[init([0; BUF1_SZ])]
-        buffer1: [u8; BUF1_SZ],
         led: Pin<Output<PushPull>>,
     }
 
     #[init]
-    fn init(ctx: init::Context) -> init::LateResources {
+    fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
         rtt_init_print!();
 
@@ -48,7 +46,7 @@ const APP: () = {
             .enable_interrupt(TwiEvent::Read) // Trigger interrupt on READ command
             .enable();
 
-        init::LateResources { twis, led }
+        (Shared {}, Local { twis, led }, init::Monotonics())
     }
 
     #[idle]
@@ -59,12 +57,15 @@ const APP: () = {
         }
     }
 
-    #[task(binds = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0, resources = [twis, buffer0, buffer1, led])]
+    #[task(binds = SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0, local = [twis, led,
+        buffer0: [u8; BUF0_SZ] = [0; BUF0_SZ],
+        buffer1: [u8; BUF1_SZ] = [0; BUF1_SZ],
+    ])]
     fn on_twis(ctx: on_twis::Context) {
-        let twis = ctx.resources.twis;
-        let buffer0 = ctx.resources.buffer0;
-        let buffer1 = ctx.resources.buffer1;
-        let led = ctx.resources.led;
+        let twis = ctx.local.twis;
+        let buffer0 = ctx.local.buffer0;
+        let buffer1 = ctx.local.buffer1;
+        let led = ctx.local.led;
 
         if twis.is_event_triggered(TwiEvent::Read) {
             twis.reset_event(TwiEvent::Read);
@@ -101,14 +102,12 @@ const APP: () = {
             }
         }
     }
-};
+}
 
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
     rprintln!("{}", info);
-    loop {
-        compiler_fence(Ordering::SeqCst);
-    }
+    loop {}
 }

--- a/examples/twis-dma-demo/Cargo.toml
+++ b/examples/twis-dma-demo/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
+cortex-m-rtic = { version = "1.0.0", default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/usb/Cargo.toml
+++ b/examples/usb/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 cortex-m-rt = "0.7.0"
 panic-semihosting = "0.5.3"
-nrf52840-pac = "0.10.1"
 usb-device = "0.2.7"
 usbd-serial = "0.1.0"
 

--- a/examples/usb/src/bin/serial.rs
+++ b/examples/usb/src/bin/serial.rs
@@ -6,13 +6,12 @@ use panic_semihosting as _;
 use cortex_m_rt::entry;
 use nrf52840_hal::clocks::Clocks;
 use nrf52840_hal::usbd::{UsbPeripheral, Usbd};
-use nrf52840_pac::Peripherals;
 use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
 #[entry]
 fn main() -> ! {
-    let periph = Peripherals::take().unwrap();
+    let periph = nrf52840_hal::pac::Peripherals::take().unwrap();
     let clocks = Clocks::new(periph.CLOCK);
     let clocks = clocks.enable_ext_hfosc();
 

--- a/examples/usb/src/bin/test_class.rs
+++ b/examples/usb/src/bin/test_class.rs
@@ -6,12 +6,11 @@ use panic_semihosting as _;
 use cortex_m_rt::entry;
 use nrf52840_hal::clocks::Clocks;
 use nrf52840_hal::usbd::{UsbPeripheral, Usbd};
-use nrf52840_pac::Peripherals;
 use usb_device::test_class::TestClass;
 
 #[entry]
 fn main() -> ! {
-    let periph = Peripherals::take().unwrap();
+    let periph = nrf52840_hal::pac::Peripherals::take().unwrap();
     let clocks = Clocks::new(periph.CLOCK);
     let clocks = clocks.enable_ext_hfosc();
 

--- a/examples/wdt-demo/Cargo.toml
+++ b/examples/wdt-demo/Cargo.toml
@@ -10,7 +10,6 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
-cortex-m-rtic = { version = "0.5.9", features = ["cortex-m-7"], default-features = false }
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
 

--- a/examples/wdt-demo/src/main.rs
+++ b/examples/wdt-demo/src/main.rs
@@ -19,201 +19,145 @@ use embedded_hal::{
     timer::CountDown,
 };
 use {
-    core::{
-        panic::PanicInfo,
-        sync::atomic::{compiler_fence, Ordering},
-    },
-    hal::pac::TIMER0,
+    core::panic::PanicInfo,
     hal::{
-        gpio::{Input, Level, Output, Pin, PullUp, PushPull},
+        gpio::Level,
         timer::Timer,
-        wdt::{count, handles::HdlN, Parts, Watchdog, WatchdogHandle},
+        wdt::{count, Parts, Watchdog},
     },
     nrf52840_hal as hal,
     rtt_target::{rprintln, rtt_init_print},
 };
 
-#[rtic::app(device = crate::hal::pac, peripherals = true, monotonic = rtic::cyccnt::CYCCNT)]
-const APP: () = {
-    struct Resources {
-        btn1: Pin<Input<PullUp>>,
-        btn2: Pin<Input<PullUp>>,
-        btn3: Pin<Input<PullUp>>,
-        btn4: Pin<Input<PullUp>>,
-        led1: Pin<Output<PushPull>>,
-        led2: Pin<Output<PushPull>>,
-        led3: Pin<Output<PushPull>>,
-        led4: Pin<Output<PushPull>>,
-        hdl0: WatchdogHandle<HdlN>,
-        hdl1: WatchdogHandle<HdlN>,
-        hdl2: WatchdogHandle<HdlN>,
-        hdl3: WatchdogHandle<HdlN>,
-        timer: Timer<TIMER0>,
-    }
+#[cortex_m_rt::entry]
+fn main() -> ! {
+    let p = hal::pac::Peripherals::take().unwrap();
+    let mut core = cortex_m::Peripherals::take().unwrap();
+    let _clocks = hal::clocks::Clocks::new(p.CLOCK).enable_ext_hfosc();
+    rtt_init_print!();
+    let p0 = hal::gpio::p0::Parts::new(p.P0);
 
-    #[init]
-    fn init(mut ctx: init::Context) -> init::LateResources {
-        let _clocks = hal::clocks::Clocks::new(ctx.device.CLOCK).enable_ext_hfosc();
-        rtt_init_print!();
-        let p0 = hal::gpio::p0::Parts::new(ctx.device.P0);
+    let btn1 = p0.p0_11.into_pullup_input().degrade();
+    let btn2 = p0.p0_12.into_pullup_input().degrade();
+    let btn3 = p0.p0_24.into_pullup_input().degrade();
+    let btn4 = p0.p0_25.into_pullup_input().degrade();
 
-        let btn1 = p0.p0_11.into_pullup_input().degrade();
-        let btn2 = p0.p0_12.into_pullup_input().degrade();
-        let btn3 = p0.p0_24.into_pullup_input().degrade();
-        let btn4 = p0.p0_25.into_pullup_input().degrade();
+    let mut led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
+    let mut led2 = p0.p0_14.into_push_pull_output(Level::High).degrade();
+    let mut led3 = p0.p0_15.into_push_pull_output(Level::High).degrade();
+    let mut led4 = p0.p0_16.into_push_pull_output(Level::High).degrade();
 
-        let led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
-        let led2 = p0.p0_14.into_push_pull_output(Level::High).degrade();
-        let led3 = p0.p0_15.into_push_pull_output(Level::High).degrade();
-        let led4 = p0.p0_16.into_push_pull_output(Level::High).degrade();
+    let mut timer = Timer::new(p.TIMER0);
 
-        let timer = Timer::new(ctx.device.TIMER0);
+    // Create a new watchdog instance
+    //
+    // In case the watchdog is already running, just spin and let it expire, since
+    // we can't configure it anyway. This usually happens when we first program
+    // the device and the watchdog was previously active
+    let (hdl0, hdl1, hdl2, hdl3) = match Watchdog::try_new(p.WDT) {
+        Ok(mut watchdog) => {
+            // Set the watchdog to timeout after 5 seconds (in 32.768kHz ticks)
+            watchdog.set_lfosc_ticks(5 * 32768);
 
-        // Create a new watchdog instance
-        //
-        // In case the watchdog is already running, just spin and let it expire, since
-        // we can't configure it anyway. This usually happens when we first program
-        // the device and the watchdog was previously active
-        let (hdl0, hdl1, hdl2, hdl3) = match Watchdog::try_new(ctx.device.WDT) {
-            Ok(mut watchdog) => {
-                // Set the watchdog to timeout after 5 seconds (in 32.768kHz ticks)
-                watchdog.set_lfosc_ticks(5 * 32768);
+            // Activate the watchdog with four handles
+            let Parts {
+                watchdog: _watchdog,
+                handles,
+            } = watchdog.activate::<count::Four>();
 
-                // Activate the watchdog with four handles
-                let Parts {
-                    watchdog: _watchdog,
-                    handles,
-                } = watchdog.activate::<count::Four>();
+            handles
+        }
+        Err(wdt) => match Watchdog::try_recover::<count::Four>(wdt) {
+            Ok(Parts { mut handles, .. }) => {
+                rprintln!("Oops, watchdog already active, but recovering!");
+
+                // Pet all the dogs quickly to reset to default timeout
+                handles.0.pet();
+                handles.1.pet();
+                handles.2.pet();
+                handles.3.pet();
 
                 handles
             }
-            Err(wdt) => match Watchdog::try_recover::<count::Four>(wdt) {
-                Ok(Parts { mut handles, .. }) => {
-                    rprintln!("Oops, watchdog already active, but recovering!");
+            Err(_wdt) => {
+                rprintln!("Oops, watchdog already active, resetting!");
+                loop {}
+            }
+        },
+    };
 
-                    // Pet all the dogs quickly to reset to default timeout
-                    handles.0.pet();
-                    handles.1.pet();
-                    handles.2.pet();
-                    handles.3.pet();
+    // Enable the monotonic timer (CYCCNT)
+    core.DCB.enable_trace();
+    core.DWT.enable_cycle_counter();
 
-                    handles
-                }
-                Err(_wdt) => {
-                    rprintln!("Oops, watchdog already active, resetting!");
-                    loop {
-                        continue;
-                    }
-                }
-            },
-        };
+    rprintln!("Starting!");
 
-        // Enable the monotonic timer (CYCCNT)
-        ctx.core.DCB.enable_trace();
-        ctx.core.DWT.enable_cycle_counter();
-
-        rprintln!("Starting!");
-
-        if ctx.device.POWER.resetreas.read().dog().is_detected() {
-            ctx.device.POWER.resetreas.modify(|_r, w| {
-                // Clear the watchdog reset reason bit
-                w.dog().set_bit()
-            });
-            rprintln!("Restarted by the dog!");
-        } else {
-            rprintln!("Not restarted by the dog!");
-        }
-
-        init::LateResources {
-            btn1,
-            btn2,
-            btn3,
-            btn4,
-            led1,
-            led2,
-            led3,
-            led4,
-            hdl0: hdl0.degrade(),
-            hdl1: hdl1.degrade(),
-            hdl2: hdl2.degrade(),
-            hdl3: hdl3.degrade(),
-            timer,
-        }
+    if p.POWER.resetreas.read().dog().is_detected() {
+        p.POWER.resetreas.modify(|_r, w| {
+            // Clear the watchdog reset reason bit
+            w.dog().set_bit()
+        });
+        rprintln!("Restarted by the dog!");
+    } else {
+        rprintln!("Not restarted by the dog!");
     }
 
-    #[idle(resources = [btn1, btn2, btn3, btn4, led1, led2, led3, led4, hdl0, hdl1, hdl2, hdl3, timer])]
-    fn idle(mut ctx: idle::Context) -> ! {
-        let buttons = [
-            &ctx.resources.btn1,
-            &ctx.resources.btn2,
-            &ctx.resources.btn3,
-            &ctx.resources.btn4,
-        ];
+    let buttons = [&btn1, &btn2, &btn3, &btn4];
 
-        let leds = [
-            &mut ctx.resources.led1,
-            &mut ctx.resources.led2,
-            &mut ctx.resources.led3,
-            &mut ctx.resources.led4,
-        ];
+    let leds = [&mut led1, &mut led2, &mut led3, &mut led4];
 
-        let handles = [
-            &mut ctx.resources.hdl0,
-            &mut ctx.resources.hdl1,
-            &mut ctx.resources.hdl2,
-            &mut ctx.resources.hdl3,
-        ];
+    let handles = [
+        &mut hdl0.degrade(),
+        &mut hdl1.degrade(),
+        &mut hdl2.degrade(),
+        &mut hdl3.degrade(),
+    ];
 
-        let timer = &mut ctx.resources.timer;
+    let mut cumulative_ticks = 0;
+    let mut any_pet = false;
 
-        let mut cumulative_ticks = 0;
-        let mut any_pet = false;
+    timer.start(1_000_000u32 * 6);
 
-        timer.start(1_000_000u32 * 6);
+    loop {
+        let mut petted = 0;
 
-        loop {
-            let mut petted = 0;
-
-            // Loop through all handles/leds/buttons
-            for i in 0..4 {
-                if !handles[i].is_pet() && buttons[i].is_low().unwrap() {
-                    rprintln!("Petting {}", i);
-                    any_pet = true;
-                    handles[i].pet();
-                    while buttons[i].is_low().unwrap() {}
-                }
-
-                if handles[i].is_pet() {
-                    petted += 1;
-                    leds[i].set_low().ok();
-                } else {
-                    leds[i].set_high().ok();
-                }
+        // Loop through all handles/leds/buttons
+        for i in 0..4 {
+            if !handles[i].is_pet() && buttons[i].is_low().unwrap() {
+                rprintln!("Petting {}", i);
+                any_pet = true;
+                handles[i].pet();
+                while buttons[i].is_low().unwrap() {}
             }
 
-            // We must have pet all handles, reset the timer
-            if any_pet && petted == 0 {
-                cumulative_ticks = 0;
-                any_pet = false;
-                timer.start(1_000_000u32 * 6);
-            }
-
-            // Check whether to update the counter time
-            let rd = timer.read();
-            if (cumulative_ticks + 250_000) <= rd {
-                cumulative_ticks = rd;
-                rprintln!("Time left: {}ms", (5_000_000 - rd) / 1_000);
+            if handles[i].is_pet() {
+                petted += 1;
+                leds[i].set_low().ok();
+            } else {
+                leds[i].set_high().ok();
             }
         }
+
+        // We must have pet all handles, reset the timer
+        if any_pet && petted == 0 {
+            cumulative_ticks = 0;
+            any_pet = false;
+            timer.start(1_000_000u32 * 6);
+        }
+
+        // Check whether to update the counter time
+        let rd = timer.read();
+        if (cumulative_ticks + 250_000) <= rd {
+            cumulative_ticks = rd;
+            rprintln!("Time left: {}ms", (5_000_000 - rd) / 1_000);
+        }
     }
-};
+}
 
 #[inline(never)]
 #[panic_handler]
 fn panic(info: &PanicInfo) -> ! {
     cortex_m::interrupt::disable();
     rprintln!("{}", info);
-    loop {
-        compiler_fence(Ordering::SeqCst);
-    }
+    loop {}
 }

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -25,8 +25,8 @@ nb = "1.0.0"
 fixed = "1.0.0"
 rand_core = "0.6.3"
 cfg-if = "1.0.0"
-embedded-dma = "0.1.1"
-embedded-storage = "0.2.0"
+embedded-dma = "0.2.0"
+embedded-storage = "0.3.0"
 
 [dependencies.void]
 default-features = false

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
     "Daniel Egger <daniel@eggers-club.de>",
-    "Ferdia McKeogh <ferdia@mckeogh.tech>"
+    "Ferdia McKeogh <ferdia@mckeogh.tech>",
 ]
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -38,35 +38,35 @@ version = "0.3.0"
 
 [dependencies.nrf51-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf52810-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf52811-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf52832-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf52833-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf52840-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf5340-app-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf9160-pac]
 optional = true
-version = "0.10.1"
+version = "0.11.0"
 
 [dependencies.nrf-usbd]
 version = "0.1.0"

--- a/nrf51-hal/Cargo.toml
+++ b/nrf51-hal/Cargo.toml
@@ -12,14 +12,14 @@ authors = [
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
     "Ferdia McKeogh <ferdia@mckeogh.tech>",
-    "Daniel Egger <daniel@eggers-club.de>"
+    "Daniel Egger <daniel@eggers-club.de>",
 ]
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf51"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-nrf51-pac = "0.10.1"
+nrf51-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52810"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-nrf52810-pac = "0.10.1"
+nrf52810-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf52811-hal/Cargo.toml
+++ b/nrf52811-hal/Cargo.toml
@@ -18,7 +18,7 @@ keywords = ["arm", "cortex-m", "nrf52", "hal", "nrf52811"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-nrf52811-pac = "0.10.1"
+nrf52811-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/nrf-rs/nrf-hal"
 authors = [
     "James Munns <james@onevariable.com>",
-    "Hanno Braun <hanno@braun-robotics.com>"
+    "Hanno Braun <hanno@braun-robotics.com>",
 ]
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-nrf52832-pac = "0.10.1"
+nrf52832-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf52833-hal/Cargo.toml
+++ b/nrf52833-hal/Cargo.toml
@@ -10,7 +10,7 @@ authors = [
     "Hanno Braun <hanno@braun-robotics.com>",
     "John Scarrott <johnps@outlook.com>",
     "Wez Furlong <wez@wezfurlong.org>",
-    "Erik Svensson <erik.public@gmail.com>"
+    "Erik Svensson <erik.public@gmail.com>",
 ]
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-nrf52833-pac = "0.10.1"
+nrf52833-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf52840-hal-tests/Cargo.toml
+++ b/nrf52840-hal-tests/Cargo.toml
@@ -34,6 +34,6 @@ cortex-m-rt = { version = "0.7.1", features = ["device"] }
 defmt = "0.3.0"
 defmt-rtt = "0.3.0"
 defmt-test = "0.3.0"
-embedded-storage = "0.2.0"
+embedded-storage = "0.3.0"
 nrf52840-hal = { path = "../nrf52840-hal" }
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -18,7 +18,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-nrf52840-pac = "0.10.1"
+nrf52840-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -7,7 +7,7 @@ readme = "../README.md"
 repository = "https://github.com/nrf-rs/nrf-hal"
 authors = [
     "Jonathan Pallant (42 Technology) <jonathan.pallant@42technology.com>",
-    "Sascha Wise <me@saschawise.com"
+    "Sascha Wise <me@saschawise.com",
 ]
 
 categories = ["embedded", "hardware-support", "no-std"]
@@ -16,7 +16,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-nrf5340-app-pac = "0.10.1"
+nrf5340-app-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -15,7 +15,7 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-nrf9160-pac = "0.10.1"
+nrf9160-pac = "0.11.0"
 
 [dependencies.nrf-hal-common]
 path = "../nrf-hal-common"

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -30,7 +30,7 @@ pub static EXAMPLES: &[(&str, &[&str])] = &[
     ),
     ("nvmc-demo", &["52840"]),
     ("pwm-blinky-demo", &["52840"]),
-    ("pwm-demo", &["52840"]),
+    ("pwm-demo", &[]),
     ("qdec-demo", &[]),
     ("rtc-demo", &[]),
     ("rtic-demo", &["51", "52810", "52811", "52832", "52840"]),


### PR DESCRIPTION
Updates the PACs to 0.11.0, `embedded-dma` and `embedded-storage` dependencies of `nrf-hal-common`, and all example dependencies (notably including RTIC 1.0).

I've removed RTIC from `wdt-demo` since it isn't needed there.