### PR TITLE
implement MultiWriteNorFlash for the nrf9160

### DIFF
--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -190,6 +190,7 @@ where
     feature = "52811",
     feature = "52833",
     feature = "52840",
+    feature = "9160",
 ))]
 impl<T: Instance> embedded_storage::nor_flash::MultiwriteNorFlash for Nvmc<T> {}
 


### PR DESCRIPTION
per the product specification [section 4.4](https://infocenter.nordicsemi.com/pdf/nRF9160_PS_v2.0.pdf#page=29) there can be n_write writes, where `t_write = 2` [source](https://infocenter.nordicsemi.com/pdf/nRF9160_PS_v2.0.pdf#page=35). Unless I'm missing something, that means that the contract of `MultiWriteNorFlash` is satisfied.
