### PR TITLE
Fixed nvms erase problem for nrf91 & nrf53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-(no changes)
+- Fixed the nvmc erase procedure on nRF91 & nRF53 ([#387])
 
 ## [0.15.0]
 

--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -87,7 +87,7 @@ where
     #[cfg(any(feature = "9160", feature = "5340-app"))]
     #[inline]
     fn erase_page(&mut self, page_offset: usize) {
-        self.direct_write_word(page_offset * PAGE_SIZE, 0xffffffff);
+        self.direct_write_word(page_offset * PAGE_SIZE / WORD_SIZE, 0xffffffff);
         self.wait_ready();
     }
 


### PR DESCRIPTION
A byte offset was given where a word offset was required (factor 4 difference)