### PR TITLE
Use `is_connected` to determine whether a ctx/rtx was connected to uarte

### DIFF
--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -296,12 +296,12 @@ where
             Pins {
                 rxd: unsafe { Pin::from_psel_bits(rxd.bits()) },
                 txd: unsafe { Pin::from_psel_bits(txd.bits()) },
-                cts: if cts.connect().bit_is_set() {
+                cts: if cts.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(cts.bits()) })
                 } else {
                     None
                 },
-                rts: if rts.connect().bit_is_set() {
+                rts: if rts.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(rts.bits()) })
                 } else {
                     None


### PR DESCRIPTION
`Uarte::free` method uses `bit_is_set` to determine whether a pin was connected to `cts` and `rts`. However, a set bit represents a disconnected pin. Use `is_connected()` instead to do the inversion.