### PR TITLE
README: Mention USB copying of Hex files

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -44,3 +44,22 @@ $ cargo install cargo-embed
 ### For Every Project (optional)
 
 Setup the `Cargo.toml` file to use the correct features. Features allow for conditional compilation which is essential for a library like this that supports multiple different devices. Under the `[features]` section add the following line `default = ["52840"]` for the nRF52840-DK device or whatever other feature is applicable for your device. This is optional but it will allow you to simply call `cargo run` and `cargo build` instead of `cargo run --features 52840` and `cargo build --features 52840` respectively. Note that some demo projects do not have features so this step may not be necessary. If you get a whole bunch of compilation errors or plugins like rust-analyzer are not working then check that you have set the chip features correctly.
+
+### Alternative flashing methods
+
+The primary way for flashing the devices is through `cargo embed`,
+as often detailed in the examples' README files.
+
+Several alternatives are available, depending on one's setup:
+
+* Programmers thar are "Mbed Enabled" usually support flashing `.hex` (Intel Hex) files by simply copying them onto the virtual USB storage device.
+
+  Suitable files are created by converting the built ELF files:
+
+  ```
+  $ cargo build --target thumbv7em-none-eabihf
+  $ arm-none-eabi-objcopy -O ihex target/thumbv7em-none-eabihf/debug/blinky-button-demo.elf /media/${USER}/JLINK/blinky-button-demo.hex
+  ```
+
+* When using debuggers in a stand-alone way,
+  these usually need to be passed the `.elf` file produced by `cargo build`.


### PR DESCRIPTION
Inspired by https://github.com/nrf-rs/nrf-hal/issues/60 (but not resolving it fully, probably), this adds text to the general examples README on alternatives to the `cargo embed` process described in the individual READMEs.

This might need a few more items on the list based on the methods listed in #60; I'll be asking there to state which methods are still relevant. (To me, only copying is relevant, as that's what works without going through the process of unlocking the AP lock that is engaged on the nrf42dk board).