### PR TITLE
Make SPI clock pin optional for use with WS2812

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,4 +2,9 @@
     "rust-analyzer.cargo.target": "thumbv7em-none-eabi",
     "rust-analyzer.checkOnSave.allTargets": false,
     "rust-analyzer.cargo.allFeatures": false,
+    "spellright.language": [],
+    "spellright.documentTypes": [
+        "markdown",
+        "latex"
+    ],
 }

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -95,7 +95,7 @@ where
     fn set_pins(spi: &mut T, pins: Pins) {
         spi.pselsck.write(|w| unsafe {
             if let Some(ref pin) = pins.sck {
-                w.bits(pins.pin().into());
+                w.bits(pins.pin().into())
             }
         });
         spi.pselmosi.write(|w| unsafe {

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -93,10 +93,11 @@ where
 
     #[cfg(feature = "51")]
     fn set_pins(spi: &mut T, pins: Pins) {
-        spi.pselsck
-            .write(|w| unsafe { w.bits(pins.sck.pin().into()) });
-
-        // Optional pins.
+        spi.pselsck.write(|w| unsafe {
+            if let Some(ref pin) = pins.sck {
+                w.bits(pins.pin().into());
+            }
+        });
         spi.pselmosi.write(|w| unsafe {
             if let Some(ref pin) = pins.mosi {
                 w.bits(pin.pin().into())

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -118,11 +118,9 @@ where
 
     #[cfg(not(feature = "51"))]
     fn set_pins(spi: &mut T, pins: Pins) {
-        spi.psel
-            .sck
-            .write(|w| unsafe { w.bits(pins.sck.pin().into()) });
-
-        // Optional pins.
+        if let Some(ref pin) = pins.sck {
+            spi.psel.sck.write(|w| unsafe { w.bits(pin.pin().into()) });
+        }
         if let Some(ref pin) = pins.mosi {
             spi.psel.mosi.write(|w| unsafe { w.bits(pin.pin().into()) });
         }
@@ -140,7 +138,9 @@ where
 /// GPIO pins for SPI interface.
 pub struct Pins {
     /// SPI clock.
-    pub sck: Pin<Output<PushPull>>,
+    ///
+    /// None if unused.
+    pub sck: Option<Pin<Output<PushPull>>>,
 
     /// MOSI Master out, slave in.
     ///


### PR DESCRIPTION
smart-leds-rs uses SPI without clock for controlling WS2812 LEDs.