### PR TITLE
Add OpenDrainIO pin state (with InputPin capability)

### DIFF
--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -85,7 +85,7 @@ use crate::pac::P1;
 #[cfg(feature = "5340-net")]
 use crate::pac::P1_NS as P1;
 
-use crate::hal::digital::v2::{InputPin, IoPin, OutputPin, PinState, StatefulOutputPin};
+use crate::hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
 use void::Void;
 
 impl<MODE> Pin<MODE> {
@@ -360,19 +360,6 @@ impl InputPin for Pin<Output<OpenDrainIO>> {
     }
 }
 
-impl IoPin<Self, Self> for Pin<Output<OpenDrainIO>> {
-    type Error = Void;
-
-    fn into_input_pin(self) -> Result<Self, Self::Error> {
-        Ok(self)
-    }
-
-    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
-        self.set_state(state)?;
-        Ok(self)
-    }
-}
-
 impl<MODE> OutputPin for Pin<Output<MODE>> {
     type Error = Void;
 
@@ -474,7 +461,7 @@ macro_rules! gpio {
                 $PX
             };
 
-            use crate::hal::digital::v2::{InputPin, IoPin, OutputPin, PinState, StatefulOutputPin};
+            use crate::hal::digital::v2::{OutputPin, StatefulOutputPin, InputPin};
             use void::Void;
 
 
@@ -696,19 +683,6 @@ macro_rules! gpio {
 
                     fn is_low(&self) -> Result<bool, Self::Error> {
                         Ok(unsafe { ((*$PX::ptr()).in_.read().bits() & (1 << $i)) == 0 })
-                    }
-                }
-
-                impl IoPin<Self, Self> for $PXi<Output<OpenDrainIO>> {
-                    type Error = Void;
-
-                    fn into_input_pin(self) -> Result<Self, Self::Error> {
-                        Ok(self)
-                    }
-
-                    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
-                        self.set_state(state)?;
-                        Ok(self)
                     }
                 }
 

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -360,14 +360,14 @@ impl InputPin for Pin<Output<OpenDrainIO>> {
     }
 }
 
-impl IoPin<Pin<Output<OpenDrainIO>>, Pin<Output<OpenDrainIO>>> for Pin<Output<OpenDrainIO>> {
+impl IoPin<Self, Self> for Pin<Output<OpenDrainIO>> {
     type Error = Void;
 
-    fn into_input_pin(self) -> Result<Pin<Output<OpenDrainIO>>, Self::Error> {
+    fn into_input_pin(self) -> Result<Self, Self::Error> {
         Ok(self)
     }
 
-    fn into_output_pin(mut self, state: PinState) -> Result<Pin<Output<OpenDrainIO>>, Self::Error> {
+    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
         self.set_state(state)?;
         Ok(self)
     }
@@ -699,14 +699,14 @@ macro_rules! gpio {
                     }
                 }
 
-                impl IoPin<$PXi<Output<OpenDrainIO>>, $PXi<Output<OpenDrainIO>>> for $PXi<Output<OpenDrainIO>> {
+                impl IoPin<Self, Self> for $PXi<Output<OpenDrainIO>> {
                     type Error = Void;
 
-                    fn into_input_pin(self) -> Result<$PXi<Output<OpenDrainIO>>, Self::Error> {
+                    fn into_input_pin(self) -> Result<Self, Self::Error> {
                         Ok(self)
                     }
 
-                    fn into_output_pin(mut self, state: PinState) -> Result<$PXi<Output<OpenDrainIO>>, Self::Error> {
+                    fn into_output_pin(mut self, state: PinState) -> Result<Self, Self::Error> {
                         self.set_state(state)?;
                         Ok(self)
                     }

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -85,7 +85,7 @@ use crate::pac::P1;
 #[cfg(feature = "5340-net")]
 use crate::pac::P1_NS as P1;
 
-use crate::hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
+use crate::hal::digital::v2::{InputPin, IoPin, OutputPin, PinState, StatefulOutputPin};
 use void::Void;
 
 impl<MODE> Pin<MODE> {
@@ -360,6 +360,19 @@ impl InputPin for Pin<Output<OpenDrainIO>> {
     }
 }
 
+impl IoPin<Pin<Output<OpenDrainIO>>, Pin<Output<OpenDrainIO>>> for Pin<Output<OpenDrainIO>> {
+    type Error = Void;
+
+    fn into_input_pin(self) -> Result<Pin<Output<OpenDrainIO>>, Self::Error> {
+        Ok(self)
+    }
+
+    fn into_output_pin(mut self, state: PinState) -> Result<Pin<Output<OpenDrainIO>>, Self::Error> {
+        self.set_state(state)?;
+        Ok(self)
+    }
+}
+
 impl<MODE> OutputPin for Pin<Output<MODE>> {
     type Error = Void;
 
@@ -461,7 +474,7 @@ macro_rules! gpio {
                 $PX
             };
 
-            use crate::hal::digital::v2::{OutputPin, StatefulOutputPin, InputPin};
+            use crate::hal::digital::v2::{InputPin, IoPin, OutputPin, PinState, StatefulOutputPin};
             use void::Void;
 
 
@@ -683,6 +696,19 @@ macro_rules! gpio {
 
                     fn is_low(&self) -> Result<bool, Self::Error> {
                         Ok(unsafe { ((*$PX::ptr()).in_.read().bits() & (1 << $i)) == 0 })
+                    }
+                }
+
+                impl IoPin<$PXi<Output<OpenDrainIO>>, $PXi<Output<OpenDrainIO>>> for $PXi<Output<OpenDrainIO>> {
+                    type Error = Void;
+
+                    fn into_input_pin(self) -> Result<$PXi<Output<OpenDrainIO>>, Self::Error> {
+                        Ok(self)
+                    }
+
+                    fn into_output_pin(mut self, state: PinState) -> Result<$PXi<Output<OpenDrainIO>>, Self::Error> {
+                        self.set_state(state)?;
+                        Ok(self)
                     }
                 }
 

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -289,7 +289,7 @@ impl<MODE> Pin<MODE> {
 
     /// Convert the pin to be an open-drain input/output.
     ///
-    /// Similar to [`open_drain_output`], but can also be read from.
+    /// Similar to [`into_open_drain_output`](Self::into_open_drain_output), but can also be read from.
     ///
     /// This method currently does not support configuring an internal pull-up or pull-down
     /// resistor.
@@ -607,7 +607,7 @@ macro_rules! gpio {
 
                     /// Convert the pin to be an open-drain input/output
                     ///
-                    /// Similar to [`open_drain_output`], but can also be read from.
+                    /// Similar to [`into_open_drain_output`](Self::into_open_drain_output), but can also be read from.
                     ///
                     /// This method currently does not support configuring an
                     /// internal pull-up or pull-down resistor.


### PR DESCRIPTION
As already reported in https://github.com/nrf-rs/nrf-hal/issues/339, there is currently no way to create an I/O pin in nrf-hal.

There are several reasons why having this would be useful. My personal usecase is the DHT22/AM2302 sensor. Controlling it requires a single-wire pulled-up open drain IO.

Sadly, this means that all libraries that can interface with it [require `InputPin + OutputPin`](https://docs.rs/dht-sensor/0.2.1/dht_sensor/trait.InputOutputPin.html).

# Solution
There is no inherent reason why nrf chips shouldn't be able to implement this. The input buffer is always available and allows reading back the pin values during every pin configuration. Although for energy saving reasons, the input buffer is currently disabled during the `OpenDrain` state.

My proposal is to add an `OpenDrainIO` state that does not disable the input buffer and implements `InputPin`.