### PR TITLE
SPIM: make SCK optional to match SPI

### DIFF
--- a/examples/i2s-peripheral-demo/src/main.rs
+++ b/examples/i2s-peripheral-demo/src/main.rs
@@ -72,7 +72,7 @@ mod app {
             spim::Pins {
                 miso: None,
                 mosi: Some(rgb_data_pin),
-                sck: rgb_clk_pin,
+                sck: Some(rgb_clk_pin),
             },
             Frequency::M4,
             SPIMode {

--- a/examples/spi-demo/src/main.rs
+++ b/examples/spi-demo/src/main.rs
@@ -44,7 +44,7 @@ fn main() -> ! {
 
     let mut tests_ok = true;
     let pins = nrf52832_hal::spim::Pins {
-        sck: spiclk,
+        sck: Some(spiclk),
         miso: Some(spimiso),
         mosi: Some(spimosi),
     };


### PR DESCRIPTION
Followup to https://github.com/nrf-rs/nrf-hal/pull/400 to make the APIs match again

bors r+