### PR TITLE
Change all psel tests to use `is_connected`

### DIFF
--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -474,19 +474,19 @@ impl I2S {
             self.i2s,
             if slave {
                 Pins::Peripheral {
-                    mck: if mck_pin.connect().bit_is_set() {
+                    mck: if mck_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(mck_pin.bits()) })
                     } else {
                         None
                     },
                     sck: unsafe { Pin::from_psel_bits(sck_pin.bits()) },
                     lrck: unsafe { Pin::from_psel_bits(lrck_pin.bits()) },
-                    sdin: if sdin_pin.connect().bit_is_set() {
+                    sdin: if sdin_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(sdin_pin.bits()) })
                     } else {
                         None
                     },
-                    sdout: if sdout_pin.connect().bit_is_set() {
+                    sdout: if sdout_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(sdout_pin.bits()) })
                     } else {
                         None
@@ -494,19 +494,19 @@ impl I2S {
                 }
             } else {
                 Pins::Controller {
-                    mck: if mck_pin.connect().bit_is_set() {
+                    mck: if mck_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(mck_pin.bits()) })
                     } else {
                         None
                     },
                     sck: unsafe { Pin::from_psel_bits(sck_pin.bits()) },
                     lrck: unsafe { Pin::from_psel_bits(lrck_pin.bits()) },
-                    sdin: if sdin_pin.connect().bit_is_set() {
+                    sdin: if sdin_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(sdin_pin.bits()) })
                     } else {
                         None
                     },
-                    sdout: if sdout_pin.connect().bit_is_set() {
+                    sdout: if sdout_pin.connect().is_connected() {
                         Some(unsafe { Pin::from_psel_bits(sdout_pin.bits()) })
                     } else {
                         None

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -760,22 +760,22 @@ where
         (
             self.pwm,
             Pins {
-                ch0: if ch0.connect().bit_is_set() {
+                ch0: if ch0.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(ch0.bits()) })
                 } else {
                     None
                 },
-                ch1: if ch1.connect().bit_is_set() {
+                ch1: if ch1.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(ch1.bits()) })
                 } else {
                     None
                 },
-                ch2: if ch2.connect().bit_is_set() {
+                ch2: if ch2.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(ch2.bits()) })
                 } else {
                     None
                 },
-                ch3: if ch3.connect().bit_is_set() {
+                ch3: if ch3.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(ch3.bits()) })
                 } else {
                     None

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -138,7 +138,7 @@ impl Qdec {
         let b = unsafe { Pin::from_psel_bits(self.qdec.psel.b.read().bits()) };
         let led = {
             let led = self.qdec.psel.led.read();
-            if led.connect().bit_is_set() {
+            if led.connect().is_connected() {
                 Some(unsafe { Pin::from_psel_bits(led.bits()) })
             } else {
                 None

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -373,17 +373,17 @@ where
         (
             self.0,
             Pins {
-                sck: if sck.connect().bit_is_set() {
+                sck: if sck.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(sck.bits()) })
                 } else {
                     None
                 },
-                mosi: if mosi.connect().bit_is_set() {
+                mosi: if mosi.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(mosi.bits()) })
                 } else {
                     None
                 },
-                miso: if miso.connect().bit_is_set() {
+                miso: if miso.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(miso.bits()) })
                 } else {
                     None

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -418,12 +418,12 @@ where
             Pins {
                 sck: unsafe { Pin::from_psel_bits(sck.bits()) },
                 cs: unsafe { Pin::from_psel_bits(cs.bits()) },
-                copi: if copi.connect().bit_is_set() {
+                copi: if copi.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(copi.bits()) })
                 } else {
                     None
                 },
-                cipo: if cipo.connect().bit_is_set() {
+                cipo: if cipo.connect().is_connected() {
                     Some(unsafe { Pin::from_psel_bits(cipo.bits()) })
                 } else {
                     None


### PR DESCRIPTION
Applies https://github.com/nrf-rs/nrf-hal/pull/397 to the whole HAL.

bors r+