### PR TITLE
Point 2 HALs to their own readme

### DIFF
--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf5340-app-hal"
 version = "0.16.0"
 description = "HAL for nRF5340 app SoC"
-readme = "../README.md"
+readme = "README.md"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
 authors = [

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "nrf9160-hal"
 version = "0.16.0"
 description = "HAL for nRF9160 system-in-package"
-readme = "../README.md"
+readme = "README.md"
 
 repository = "https://github.com/nrf-rs/nrf-hal"
 authors = [


### PR DESCRIPTION
These 2 have a more specific readme than the repository-wide one, and `cargo publish` warns about the link in the `Cargo.toml`.

bors r+