### PR TITLE
Correct eb3b96b with a useful function signature for try_wait

### DIFF
--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -693,20 +693,6 @@ impl<B> Transfer<B> {
         }
     }
 
-    /// Attempts to return the buffer if the transfer is done.
-    pub fn try_wait(mut self) -> Option<(B, I2S)> {
-        if self.is_done() {
-            let inner = self
-                .inner
-                .take()
-                .unwrap_or_else(|| unsafe { core::hint::unreachable_unchecked() });
-            compiler_fence(Ordering::Acquire);
-            Some((inner.buffer, inner.i2s))
-        } else {
-            None
-        }
-    }
-
     /// Blocks until the transfer is done and returns the buffer.
     pub fn wait(mut self) -> (B, I2S) {
         while !self.is_done() {}


### PR DESCRIPTION
This is embarrassing. It appears my quality assurance for #412, while existent, was way flawed and insufficient.

Having a `try_` method take ownership over self makes it impossible call it more than once. Clearly a mutable reference was what was indented and required to actually make the method meaningful.

It would be a good idea to either merge this PR, or revert the previous one, prior to making the next release.