### PR TITLE
Implement embedded-hal 1.0 traits

### DIFF
--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -76,7 +76,8 @@ version = "0.12.2"
 version = "0.2.0"
 optional = true
 
-[dependencies.embedded-hal]
+[dependencies.embedded-hal-02]
+package = "embedded-hal"
 features = ["unproven"]
 version = "0.2.4"
 

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -81,6 +81,9 @@ package = "embedded-hal"
 features = ["unproven"]
 version = "0.2.4"
 
+[dependencies.embedded-hal]
+version = "1.0.0"
+
 [features]
 doc = []
 51 = ["nrf51-pac"]

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -84,6 +84,9 @@ version = "0.2.4"
 [dependencies.embedded-hal]
 version = "1.0.0"
 
+[dependencies.embedded-io]
+version = "0.6.1"
+
 [features]
 doc = []
 51 = ["nrf51-pac"]

--- a/nrf-hal-common/src/adc.rs
+++ b/nrf-hal-common/src/adc.rs
@@ -1,6 +1,6 @@
 //! API for the Analog to Digital converter.
 
-use embedded_hal::adc::{Channel, OneShot};
+use embedded_hal_02::adc::{Channel, OneShot};
 
 use core::hint::unreachable_unchecked;
 
@@ -128,7 +128,7 @@ macro_rules! channel_mappings {
             impl Channel<Adc> for $pin {
                 type ID = u8;
 
-                fn channel() -> <Self as embedded_hal::adc::Channel<Adc>>::ID {
+                fn channel() -> <Self as embedded_hal_02::adc::Channel<Adc>>::ID {
                     $n
                 }
             }

--- a/nrf-hal-common/src/delay.rs
+++ b/nrf-hal-common/src/delay.rs
@@ -1,8 +1,9 @@
 //! Delays.
-use cortex_m::peripheral::syst::SystClkSource;
-use cortex_m::peripheral::SYST;
 
 use crate::clocks::HFCLK_FREQ;
+use core::convert::TryInto;
+use cortex_m::peripheral::syst::SystClkSource;
+use cortex_m::peripheral::SYST;
 use embedded_hal::delay::DelayNs;
 use embedded_hal_02::blocking::delay::{DelayMs, DelayUs};
 
@@ -66,7 +67,9 @@ impl DelayNs for Delay {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
-        let mut total_rvr = ns * (HFCLK_FREQ / 1_000_000_000);
+        let mut total_rvr: u32 = (u64::from(ns) * u64::from(HFCLK_FREQ) / 1_000_000_000)
+            .try_into()
+            .unwrap();
 
         while total_rvr != 0 {
             let current_rvr = if total_rvr <= MAX_RVR {

--- a/nrf-hal-common/src/delay.rs
+++ b/nrf-hal-common/src/delay.rs
@@ -4,7 +4,7 @@ use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
 use crate::clocks::HFCLK_FREQ;
-use crate::hal::blocking::delay::{DelayMs, DelayUs};
+use embedded_hal_02::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider.
 pub struct Delay {

--- a/nrf-hal-common/src/delay.rs
+++ b/nrf-hal-common/src/delay.rs
@@ -1,9 +1,9 @@
 //! Delays.
-use cast::u32;
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
 use crate::clocks::HFCLK_FREQ;
+use embedded_hal::delay::DelayNs;
 use embedded_hal_02::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider.
@@ -27,28 +27,46 @@ impl Delay {
 
 impl DelayMs<u32> for Delay {
     fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
+        DelayNs::delay_ms(self, ms);
     }
 }
 
 impl DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32(ms));
+        DelayNs::delay_ms(self, ms.into());
     }
 }
 
 impl DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32(ms));
+        DelayNs::delay_ms(self, ms.into());
     }
 }
 
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
+        DelayNs::delay_us(self, us);
+    }
+}
+
+impl DelayUs<u16> for Delay {
+    fn delay_us(&mut self, us: u16) {
+        DelayNs::delay_us(self, us.into());
+    }
+}
+
+impl DelayUs<u8> for Delay {
+    fn delay_us(&mut self, us: u8) {
+        DelayNs::delay_us(self, us.into());
+    }
+}
+
+impl DelayNs for Delay {
+    fn delay_ns(&mut self, ns: u32) {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
-        let mut total_rvr = us * (HFCLK_FREQ / 1_000_000);
+        let mut total_rvr = ns * (HFCLK_FREQ / 1_000_000_000);
 
         while total_rvr != 0 {
             let current_rvr = if total_rvr <= MAX_RVR {
@@ -68,17 +86,5 @@ impl DelayUs<u32> for Delay {
 
             self.syst.disable_counter();
         }
-    }
-}
-
-impl DelayUs<u16> for Delay {
-    fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32(us))
-    }
-}
-
-impl DelayUs<u8> for Delay {
-    fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32(us))
     }
 }

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -85,7 +85,7 @@ use crate::pac::P1;
 #[cfg(feature = "5340-net")]
 use crate::pac::P1_NS as P1;
 
-use crate::hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
+use embedded_hal_02::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
 use void::Void;
 
 impl<MODE> Pin<MODE> {
@@ -482,7 +482,7 @@ macro_rules! gpio {
                 $PX
             };
 
-            use crate::hal::digital::v2::{OutputPin, StatefulOutputPin, InputPin};
+            use embedded_hal_02::digital::v2::{OutputPin, StatefulOutputPin, InputPin};
             use void::Void;
 
 

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -1,4 +1,4 @@
-use core::marker::PhantomData;
+use core::{convert::Infallible, marker::PhantomData};
 
 /// Disconnected pin in input mode (type state, reset value).
 pub struct Disconnected;
@@ -85,7 +85,7 @@ use crate::pac::P1;
 #[cfg(feature = "5340-net")]
 use crate::pac::P1_NS as P1;
 
-use embedded_hal_02::digital::v2::{InputPin, OutputPin, StatefulOutputPin};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
 use void::Void;
 
 impl<MODE> Pin<MODE> {
@@ -348,19 +348,63 @@ impl<MODE> Pin<MODE> {
     }
 }
 
-impl<MODE> InputPin for Pin<Input<MODE>> {
-    type Error = Void;
+impl<MODE> ErrorType for Pin<MODE> {
+    type Error = Infallible;
+}
 
-    fn is_high(&self) -> Result<bool, Self::Error> {
+impl<MODE> InputPin for Pin<Input<MODE>> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         self.is_low().map(|v| !v)
     }
 
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         Ok(self.block().in_.read().bits() & (1 << self.pin()) == 0)
     }
 }
 
 impl InputPin for Pin<Output<OpenDrainIO>> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        self.is_low().map(|v| !v)
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(self.block().in_.read().bits() & (1 << self.pin()) == 0)
+    }
+}
+
+impl<MODE> OutputPin for Pin<Output<MODE>> {
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        // NOTE(unsafe) atomic write to a stateless register - TODO(AJM) verify?
+        // TODO - I wish I could do something like `.pins$i()`...
+        unsafe {
+            self.block().outset.write(|w| w.bits(1u32 << self.pin()));
+        }
+        Ok(())
+    }
+
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        // NOTE(unsafe) atomic write to a stateless register - TODO(AJM) verify?
+        // TODO - I wish I could do something like `.pins$i()`...
+        unsafe {
+            self.block().outclr.write(|w| w.bits(1u32 << self.pin()));
+        }
+        Ok(())
+    }
+}
+
+impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        self.is_set_low().map(|v| !v)
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        // NOTE(unsafe) atomic read with no side effects - TODO(AJM) verify?
+        // TODO - I wish I could do something like `.pins$i()`...
+        Ok(self.block().out.read().bits() & (1 << self.pin()) == 0)
+    }
+}
+
+impl<MODE> embedded_hal_02::digital::v2::InputPin for Pin<Input<MODE>> {
     type Error = Void;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -372,7 +416,19 @@ impl InputPin for Pin<Output<OpenDrainIO>> {
     }
 }
 
-impl<MODE> OutputPin for Pin<Output<MODE>> {
+impl embedded_hal_02::digital::v2::InputPin for Pin<Output<OpenDrainIO>> {
+    type Error = Void;
+
+    fn is_high(&self) -> Result<bool, Self::Error> {
+        self.is_low().map(|v| !v)
+    }
+
+    fn is_low(&self) -> Result<bool, Self::Error> {
+        Ok(self.block().in_.read().bits() & (1 << self.pin()) == 0)
+    }
+}
+
+impl<MODE> embedded_hal_02::digital::v2::OutputPin for Pin<Output<MODE>> {
     type Error = Void;
 
     /// Set the output as high.
@@ -396,7 +452,7 @@ impl<MODE> OutputPin for Pin<Output<MODE>> {
     }
 }
 
-impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
+impl<MODE> embedded_hal_02::digital::v2::StatefulOutputPin for Pin<Output<MODE>> {
     /// Is the output pin set as high?
     fn is_set_high(&self) -> Result<bool, Self::Error> {
         self.is_set_low().map(|v| !v)
@@ -482,9 +538,9 @@ macro_rules! gpio {
                 $PX
             };
 
-            use embedded_hal_02::digital::v2::{OutputPin, StatefulOutputPin, InputPin};
+            use core::convert::Infallible;
+            use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
             use void::Void;
-
 
             // ===============================================================
             // This chunk allows you to obtain an nrf-hal gpio from the
@@ -695,7 +751,58 @@ macro_rules! gpio {
                     }
                 }
 
+                impl<MODE> ErrorType for $PXi<MODE> {
+                    type Error = Infallible;
+                }
+
                 impl<MODE> InputPin for $PXi<Input<MODE>> {
+                    fn is_high(&mut self) -> Result<bool, Self::Error> {
+                        self.is_low().map(|v| !v)
+                    }
+
+                    fn is_low(&mut self) -> Result<bool, Self::Error> {
+                        Ok(unsafe { ((*$PX::ptr()).in_.read().bits() & (1 << $i)) == 0 })
+                    }
+                }
+
+                impl InputPin for $PXi<Output<OpenDrainIO>> {
+                    fn is_high(&mut self) -> Result<bool, Self::Error> {
+                        self.is_low().map(|v| !v)
+                    }
+
+                    fn is_low(&mut self) -> Result<bool, Self::Error> {
+                        Ok(unsafe { ((*$PX::ptr()).in_.read().bits() & (1 << $i)) == 0 })
+                    }
+                }
+                impl<MODE> OutputPin for $PXi<Output<MODE>> {
+                    fn set_high(&mut self) -> Result<(), Self::Error> {
+                        // NOTE(unsafe) atomic write to a stateless register - TODO(AJM) verify?
+                        // TODO - I wish I could do something like `.pins$i()`...
+                        unsafe { (*$PX::ptr()).outset.write(|w| w.bits(1u32 << $i)); }
+                        Ok(())
+                    }
+
+                    fn set_low(&mut self) -> Result<(), Self::Error> {
+                        // NOTE(unsafe) atomic write to a stateless register - TODO(AJM) verify?
+                        // TODO - I wish I could do something like `.pins$i()`...
+                        unsafe { (*$PX::ptr()).outclr.write(|w| w.bits(1u32 << $i)); }
+                        Ok(())
+                    }
+                }
+
+                impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
+                    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+                        self.is_set_low().map(|v| !v)
+                    }
+
+                    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+                        // NOTE(unsafe) atomic read with no side effects - TODO(AJM) verify?
+                        // TODO - I wish I could do something like `.pins$i()`...
+                        Ok(unsafe { ((*$PX::ptr()).out.read().bits() & (1 << $i)) == 0 })
+                    }
+                }
+
+                impl<MODE> embedded_hal_02::digital::v2::InputPin for $PXi<Input<MODE>> {
                     type Error = Void;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -707,7 +814,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl InputPin for $PXi<Output<OpenDrainIO>> {
+                impl embedded_hal_02::digital::v2::InputPin for $PXi<Output<OpenDrainIO>> {
                     type Error = Void;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -725,7 +832,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> OutputPin for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal_02::digital::v2::OutputPin for $PXi<Output<MODE>> {
                     type Error = Void;
 
                     /// Set the output as high
@@ -745,7 +852,7 @@ macro_rules! gpio {
                     }
                 }
 
-                impl<MODE> StatefulOutputPin for $PXi<Output<MODE>> {
+                impl<MODE> embedded_hal_02::digital::v2::StatefulOutputPin for $PXi<Output<MODE>> {
                     /// Is the output pin set as high?
                     fn is_set_high(&self) -> Result<bool, Self::Error> {
                         self.is_set_low().map(|v| !v)

--- a/nrf-hal-common/src/ieee802154.rs
+++ b/nrf-hal-common/src/ieee802154.rs
@@ -6,7 +6,7 @@ use core::{
     sync::atomic::{self, Ordering},
 };
 
-use embedded_hal::timer::CountDown as _;
+use embedded_hal_02::timer::CountDown as _;
 
 use crate::{
     clocks::{Clocks, ExternalOscillator},

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -4,8 +4,6 @@
 #![doc(html_root_url = "https://docs.rs/nrf-hal-common/0.16.1")]
 #![no_std]
 
-use embedded_hal as hal;
-
 #[cfg(feature = "51")]
 pub use nrf51_pac as pac;
 
@@ -114,8 +112,8 @@ pub mod usbd;
 pub mod wdt;
 
 pub mod prelude {
-    pub use crate::hal::digital::v2::*;
-    pub use crate::hal::prelude::*;
+    pub use embedded_hal_02::digital::v2::*;
+    pub use embedded_hal_02::prelude::*;
 
     #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "5340-net")))]
     pub use crate::ppi::{ConfigurablePpi, Ppi};

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -15,10 +15,12 @@ use crate::{
 };
 use core::{
     cell::Cell,
+    convert::Infallible,
     ops::Deref,
     sync::atomic::{compiler_fence, Ordering},
 };
 use embedded_dma::*;
+use embedded_hal::pwm::{ErrorType, SetDutyCycle};
 
 const MAX_SEQ_LEN: usize = 0x7FFF;
 
@@ -968,6 +970,21 @@ impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmChannel<'a, T> {
     }
 }
 
+impl<'a, T: Instance> ErrorType for PwmChannel<'a, T> {
+    type Error = Infallible;
+}
+
+impl<'a, T: Instance> SetDutyCycle for PwmChannel<'a, T> {
+    fn max_duty_cycle(&self) -> u16 {
+        self.max_duty()
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        self.set_duty_on(duty);
+        Ok(())
+    }
+}
+
 /// PWM group
 #[derive(Debug)]
 pub struct PwmGroup<'a, T: Instance> {
@@ -1028,6 +1045,21 @@ impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmGroup<'a, T> {
 
     fn set_duty(&mut self, duty: u16) {
         self.set_duty_on(duty)
+    }
+}
+
+impl<'a, T: Instance> ErrorType for PwmGroup<'a, T> {
+    type Error = Infallible;
+}
+
+impl<'a, T: Instance> SetDutyCycle for PwmGroup<'a, T> {
+    fn max_duty_cycle(&self) -> u16 {
+        self.max_duty()
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        self.set_duty_on(duty);
+        Ok(())
     }
 }
 

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -867,7 +867,7 @@ where
     }
 }
 
-impl<T: Instance> embedded_hal::Pwm for Pwm<T> {
+impl<T: Instance> embedded_hal_02::Pwm for Pwm<T> {
     type Channel = Channel;
     type Duty = u16;
     type Time = Hertz;
@@ -944,7 +944,7 @@ impl<'a, T: Instance> PwmChannel<'a, T> {
     }
 }
 
-impl<'a, T: Instance> embedded_hal::PwmPin for PwmChannel<'a, T> {
+impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmChannel<'a, T> {
     type Duty = u16;
 
     fn disable(&mut self) {
@@ -1007,7 +1007,7 @@ impl<'a, T: Instance> PwmGroup<'a, T> {
     }
 }
 
-impl<'a, T: Instance> embedded_hal::PwmPin for PwmGroup<'a, T> {
+impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmGroup<'a, T> {
     type Duty = u16;
 
     fn disable(&mut self) {

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -36,7 +36,7 @@ use core::{
     hint::unreachable_unchecked,
     sync::atomic::{compiler_fence, Ordering::SeqCst},
 };
-use embedded_hal::adc::{Channel, OneShot};
+use embedded_hal_02::adc::{Channel, OneShot};
 
 pub use saadc::{
     ch::config::{GAIN_A as Gain, REFSEL_A as Reference, RESP_A as Resistor, TACQ_A as Time},
@@ -230,7 +230,7 @@ macro_rules! channel_mappings {
             impl<STATE> Channel<Saadc> for crate::gpio::p0::$pin<STATE> {
                 type ID = u8;
 
-                fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
+                fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
                     $n
                 }
             }
@@ -266,7 +266,7 @@ channel_mappings! {
 impl Channel<Saadc> for InternalVdd {
     type ID = u8;
 
-    fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
+    fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
         8
     }
 }
@@ -279,7 +279,7 @@ pub struct InternalVdd;
 impl Channel<Saadc> for InternalVddHdiv5 {
     type ID = u8;
 
-    fn channel() -> <Self as embedded_hal::adc::Channel<Saadc>>::ID {
+    fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
         13
     }
 }

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -6,7 +6,7 @@ use crate::{
     pac::{spi0, SPI0},
 };
 
-pub use embedded_hal::{
+pub use embedded_hal_02::{
     blocking::spi::{transfer, write, write_iter},
     spi::{FullDuplex, Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3},
 };

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -4,6 +4,8 @@
 
 use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
+use embedded_hal::digital::OutputPin;
+use embedded_hal::spi::{self, ErrorKind, ErrorType, SpiBus};
 
 #[cfg(any(feature = "9160", feature = "5340-app", feature = "5340-net"))]
 use crate::pac::{spim0_ns as spim0, SPIM0_NS as SPIM0};
@@ -31,7 +33,6 @@ use crate::pac::SPIM3;
 use crate::gpio::{Floating, Input, Output, Pin, PushPull};
 use crate::target_constants::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
 use crate::{slice_in_ram, slice_in_ram_or, DmaSlice};
-use embedded_hal_02::digital::v2::OutputPin;
 
 /// Interface to a SPIM instance.
 ///
@@ -40,6 +41,61 @@ use embedded_hal_02::digital::v2::OutputPin;
 ///   SPI, TWIM, TWIS, and TWI. You need to make sure that conflicting instances
 ///   are disabled before using `Spim`. See product specification, section 15.2.
 pub struct Spim<T>(T);
+
+impl<T> ErrorType for Spim<T> {
+    type Error = Error;
+}
+
+impl<T: Instance> SpiBus for Spim<T> {
+    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        // A mutable slice can only be built from data in RAM.
+        assert!(slice_in_ram(words));
+
+        for chunk in words.chunks(EASY_DMA_SIZE) {
+            self.do_spi_dma_transfer(DmaSlice::null(), DmaSlice::from_slice(chunk))?;
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        if slice_in_ram(words) {
+            for chunk in words.chunks(EASY_DMA_SIZE) {
+                self.do_spi_dma_transfer(DmaSlice::from_slice(chunk), DmaSlice::null())?;
+            }
+        } else {
+            let mut buf = [0u8; FORCE_COPY_BUFFER_SIZE];
+            for chunk in words.chunks(FORCE_COPY_BUFFER_SIZE) {
+                buf[..chunk.len()].copy_from_slice(chunk);
+                self.do_spi_dma_transfer(
+                    DmaSlice::from_slice(&buf[..chunk.len()]),
+                    DmaSlice::null(),
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        self.transfer_split_uneven_internal(write, read)
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        // A mutable slice can only be built from data in RAM.
+        assert!(slice_in_ram(words));
+
+        words.chunks(EASY_DMA_SIZE).try_for_each(|chunk| {
+            self.do_spi_dma_transfer(DmaSlice::from_slice(chunk), DmaSlice::from_slice(chunk))
+        })?;
+
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        // This implementation doesn't buffer operations, so there is nothing to flush.
+        Ok(())
+    }
+}
 
 impl<T> embedded_hal_02::blocking::spi::Transfer<u8> for Spim<T>
 where
@@ -85,6 +141,7 @@ where
         words.chunks(chunk_sz).try_for_each(|c| step(self, c))
     }
 }
+
 impl<T> Spim<T>
 where
     T: Instance,
@@ -304,48 +361,63 @@ where
         tx_buffer: &[u8],
         rx_buffer: &mut [u8],
     ) -> Result<(), Error> {
-        // NOTE: RAM slice check for `rx_buffer` is not necessary, as a mutable
-        // slice can only be built from data located in RAM.
         slice_in_ram_or(tx_buffer, Error::DMABufferNotInDataMemory)?;
 
-        // For the tx and rx, we want to return Some(chunk)
-        // as long as there is data to send. We then chain a repeat to
-        // the end so once all chunks have been exhausted, we will keep
-        // getting Nones out of the iterators.
-        let txi = tx_buffer
-            .chunks(EASY_DMA_SIZE)
-            .map(Some)
-            .chain(repeat_with(|| None));
-
-        let rxi = rx_buffer
-            .chunks_mut(EASY_DMA_SIZE)
-            .map(Some)
-            .chain(repeat_with(|| None));
-
         chip_select.set_low().unwrap();
-
-        // We then chain the iterators together, and once BOTH are feeding
-        // back Nones, then we are done sending and receiving.
-        //
         // Don't return early, as we must reset the CS pin.
-        let res = txi
-            .zip(rxi)
-            .take_while(|(t, r)| t.is_some() || r.is_some())
-            // We also turn the slices into either a DmaSlice (if there was data), or a null
-            // DmaSlice (if there is no data).
-            .map(|(t, r)| {
-                (
-                    t.map(|t| DmaSlice::from_slice(t))
-                        .unwrap_or_else(DmaSlice::null),
-                    r.map(|r| DmaSlice::from_slice(r))
-                        .unwrap_or_else(DmaSlice::null),
-                )
-            })
-            .try_for_each(|(t, r)| self.do_spi_dma_transfer(t, r));
-
+        let res = self.transfer_split_uneven_internal(tx_buffer, rx_buffer);
         chip_select.set_high().unwrap();
-
         res
+    }
+
+    pub fn transfer_split_uneven_internal(
+        &mut self,
+        tx_buffer: &[u8],
+        rx_buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        // NOTE: RAM slice check for `rx_buffer` is not necessary, as a mutable
+        // slice can only be built from data located in RAM.
+        if slice_in_ram(tx_buffer) {
+            // For the tx and rx, we want to return a DmaSlice with a chunk as long
+            // as there is data to send. We then chain a repeat to the end so once
+            // all chunks have been exhausted, we will keep DmaSlice::null() out of
+            // the iterators.
+            let txi = tx_buffer
+                .chunks(EASY_DMA_SIZE)
+                .map(|chunk| DmaSlice::from_slice(chunk))
+                .chain(repeat_with(DmaSlice::null));
+            let rxi = rx_buffer
+                .chunks_mut(EASY_DMA_SIZE)
+                .map(|chunk| DmaSlice::from_slice(chunk))
+                .chain(repeat_with(DmaSlice::null));
+
+            // We then chain the iterators together, and once BOTH are giving null
+            // DmaSlices, then we are done sending and receiving.
+            for (t, r) in txi.zip(rxi).take_while(|(t, r)| t.ptr != 0 || r.ptr != 0) {
+                self.do_spi_dma_transfer(t, r)?;
+            }
+        } else {
+            let mut buf = [0u8; FORCE_COPY_BUFFER_SIZE];
+            let txi = tx_buffer
+                .chunks(FORCE_COPY_BUFFER_SIZE)
+                .map(Some)
+                .chain(repeat_with(|| None));
+            let rxi = rx_buffer
+                .chunks_mut(FORCE_COPY_BUFFER_SIZE)
+                .map(|chunk| DmaSlice::from_slice(chunk))
+                .chain(repeat_with(DmaSlice::null));
+            for (tx_chunk, r) in txi.zip(rxi).take_while(|(t, r)| t.is_some() || r.ptr != 0) {
+                let t = if let Some(tx_chunk) = tx_chunk {
+                    buf[..tx_chunk.len()].copy_from_slice(tx_chunk);
+                    DmaSlice::from_slice(&buf[..tx_chunk.len()])
+                } else {
+                    DmaSlice::null()
+                };
+                self.do_spi_dma_transfer(t, r)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Write to an SPI slave.
@@ -411,12 +483,16 @@ pub struct Pins {
 
 #[derive(Debug)]
 pub enum Error {
-    TxBufferTooLong,
-    RxBufferTooLong,
     /// EasyDMA can only read from data memory, read only buffers in flash will fail.
     DMABufferNotInDataMemory,
     Transmit,
     Receive,
+}
+
+impl spi::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Other
+    }
 }
 
 /// Implemented by all SPIM instances.

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -14,7 +14,7 @@ use crate::pac::{SPIM1_NS as SPIM1, SPIM2_NS as SPIM2, SPIM3_NS as SPIM3};
 #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "5340-net")))]
 use crate::pac::{spim0, SPIM0};
 
-pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use spim0::frequency::FREQUENCY_A as Frequency;
 
 use core::iter::repeat_with;
@@ -31,7 +31,7 @@ use crate::pac::SPIM3;
 use crate::gpio::{Floating, Input, Output, Pin, PushPull};
 use crate::target_constants::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
 use crate::{slice_in_ram, slice_in_ram_or, DmaSlice};
-use embedded_hal::digital::v2::OutputPin;
+use embedded_hal_02::digital::v2::OutputPin;
 
 /// Interface to a SPIM instance.
 ///
@@ -41,7 +41,7 @@ use embedded_hal::digital::v2::OutputPin;
 ///   are disabled before using `Spim`. See product specification, section 15.2.
 pub struct Spim<T>(T);
 
-impl<T> embedded_hal::blocking::spi::Transfer<u8> for Spim<T>
+impl<T> embedded_hal_02::blocking::spi::Transfer<u8> for Spim<T>
 where
     T: Instance,
 {
@@ -59,7 +59,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::spi::Write<u8> for Spim<T>
+impl<T> embedded_hal_02::blocking::spi::Write<u8> for Spim<T>
 where
     T: Instance,
 {

--- a/nrf-hal-common/src/timer.rs
+++ b/nrf-hal-common/src/timer.rs
@@ -20,7 +20,7 @@ use crate::pac::{
     Interrupt, TIMER0, TIMER1, TIMER2,
 };
 use cast::u32;
-use embedded_hal::{
+use embedded_hal_02::{
     blocking::delay::{DelayMs, DelayUs},
     prelude::*,
     timer,

--- a/nrf-hal-common/src/timer.rs
+++ b/nrf-hal-common/src/timer.rs
@@ -20,6 +20,7 @@ use crate::pac::{
     Interrupt, TIMER0, TIMER1, TIMER2,
 };
 use cast::u32;
+use embedded_hal::delay::DelayNs;
 use embedded_hal_02::{
     blocking::delay::{DelayMs, DelayUs},
     prelude::*,
@@ -299,7 +300,7 @@ where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u32) {
-        self.delay_us(ms * 1_000);
+        DelayUs::delay_us(self, ms * 1_000);
     }
 }
 
@@ -308,7 +309,7 @@ where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u16) {
-        self.delay_ms(u32(ms));
+        DelayMs::delay_ms(self, u32(ms));
     }
 }
 
@@ -317,7 +318,7 @@ where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u8) {
-        self.delay_ms(u32(ms));
+        DelayMs::delay_ms(self, u32(ms));
     }
 }
 
@@ -335,7 +336,7 @@ where
     T: Instance,
 {
     fn delay_us(&mut self, us: u16) {
-        self.delay_us(u32(us))
+        DelayUs::delay_us(self, u32(us))
     }
 }
 
@@ -344,7 +345,13 @@ where
     T: Instance,
 {
     fn delay_us(&mut self, us: u8) {
-        self.delay_us(u32(us))
+        DelayUs::delay_us(self, u32(us))
+    }
+}
+
+impl<T: Instance, U> DelayNs for Timer<T, U> {
+    fn delay_ns(&mut self, ns: u32) {
+        self.delay(ns / 1_000);
     }
 }
 

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -250,7 +250,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::Write for Twi<T>
+impl<T> embedded_hal_02::blocking::i2c::Write for Twi<T>
 where
     T: Instance,
 {
@@ -261,7 +261,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::Read for Twi<T>
+impl<T> embedded_hal_02::blocking::i2c::Read for Twi<T>
 where
     T: Instance,
 {
@@ -272,7 +272,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::WriteRead for Twi<T>
+impl<T> embedded_hal_02::blocking::i2c::WriteRead for Twi<T>
 where
     T: Instance,
 {

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -394,7 +394,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::Write for Twim<T>
+impl<T> embedded_hal_02::blocking::i2c::Write for Twim<T>
 where
     T: Instance,
 {
@@ -414,7 +414,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::Read for Twim<T>
+impl<T> embedded_hal_02::blocking::i2c::Read for Twim<T>
 where
     T: Instance,
 {
@@ -425,7 +425,7 @@ where
     }
 }
 
-impl<T> embedded_hal::blocking::i2c::WriteRead for Twim<T>
+impl<T> embedded_hal_02::blocking::i2c::WriteRead for Twim<T>
 where
     T: Instance,
 {

--- a/nrf-hal-common/src/uart.rs
+++ b/nrf-hal-common/src/uart.rs
@@ -99,7 +99,7 @@ where
     }
 }
 
-impl<T> embedded_hal::serial::Read<u8> for Uart<T>
+impl<T> embedded_hal_02::serial::Read<u8> for Uart<T>
 where
     T: Instance,
 {
@@ -121,7 +121,7 @@ where
     }
 }
 
-impl<T> embedded_hal::serial::Write<u8> for Uart<T>
+impl<T> embedded_hal_02::serial::Write<u8> for Uart<T>
 where
     T: Instance,
 {
@@ -150,10 +150,10 @@ where
 
 impl<T> Write for Uart<T>
 where
-    Uart<T>: embedded_hal::serial::Write<u8>,
+    Uart<T>: embedded_hal_02::serial::Write<u8>,
 {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        use embedded_hal::serial::Write;
+        use embedded_hal_02::serial::Write;
         let _ = s.as_bytes().iter().map(|c| block!(self.write(*c))).last();
         Ok(())
     }

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -4,23 +4,23 @@
 //!
 //! - nrf52832: Section 35
 //! - nrf52840: Section 6.34
+
+use core::cmp::min;
 use core::fmt;
+use core::hint::spin_loop;
 use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
-
 use embedded_hal_02::blocking::serial as bserial;
 use embedded_hal_02::digital::v2::OutputPin;
 use embedded_hal_02::serial;
+use embedded_io::{ErrorKind, ErrorType, ReadReady, WriteReady};
 
 #[cfg(any(feature = "52833", feature = "52840"))]
 use crate::pac::UARTE1;
 
 #[cfg(feature = "9160")]
 use crate::pac::{
-    uarte0_ns as uarte0,
-    UARTE0_NS as UARTE0,
-    UARTE1_NS as UARTE1,
-    UARTE2_NS as UARTE2,
+    uarte0_ns as uarte0, UARTE0_NS as UARTE0, UARTE1_NS as UARTE1, UARTE2_NS as UARTE2,
     UARTE3_NS as UARTE3,
 };
 
@@ -421,6 +421,9 @@ fn start_read(uarte: &uarte0::RegisterBlock, rx_buffer: &mut [u8]) -> Result<(),
     uarte.tasks_startrx.write(|w|
             // `1` is a valid value to write to task registers.
             unsafe { w.bits(1) });
+    while uarte.events_rxstarted.read().bits() == 0 {
+        spin_loop();
+    }
 
     Ok(())
 }
@@ -490,6 +493,20 @@ pub enum Error {
     Receive,
     Timeout(usize),
     BufferNotInRAM,
+}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Self::TxBufferTooSmall
+            | Self::RxBufferTooSmall
+            | Self::TxBufferTooLong
+            | Self::RxBufferTooLong
+            | Self::BufferNotInRAM => ErrorKind::InvalidInput,
+            Self::Transmit | Self::Receive => ErrorKind::Interrupted,
+            Self::Timeout(_) => ErrorKind::TimedOut,
+        }
+    }
 }
 
 pub trait Instance: Deref<Target = uarte0::RegisterBlock> + sealed::Sealed {
@@ -662,6 +679,52 @@ where
     }
 }
 
+impl<T: Instance> ErrorType for UarteTx<T> {
+    type Error = Error;
+}
+
+impl<T: Instance> WriteReady for UarteTx<T> {
+    fn write_ready(&mut self) -> Result<bool, Self::Error> {
+        let uarte = unsafe { &*T::ptr() };
+
+        let dma_transfer_in_progress =
+            uarte.events_txstarted.read().bits() == 1 && uarte.events_endtx.read().bits() == 0;
+
+        Ok(!dma_transfer_in_progress && self.written < self.tx_buf.len())
+    }
+}
+
+impl<T: Instance> embedded_io::Write for UarteTx<T> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        // If the internal buffer is full or a DMA transfer is in progress, flush and block until it
+        // is finished.
+        if !self.write_ready()? {
+            nb::block!(serial::Write::flush(self))?;
+        }
+
+        // Copy as many bytes as possible to the internal TX buffer.
+        let length_to_copy = min(buf.len(), self.tx_buf.len() - self.written);
+        self.tx_buf[self.written..].copy_from_slice(&buf[..length_to_copy]);
+        self.written += length_to_copy;
+
+        // If the internal buffer is now full, flush but don't block.
+        match serial::Write::flush(self) {
+            Err(nb::Error::Other(e)) => return Err(e),
+            _ => {}
+        }
+
+        Ok(length_to_copy)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        nb::block!(serial::Write::flush(self))
+    }
+}
+
 impl<T> serial::Write<u8> for UarteTx<T>
 where
     T: Instance,
@@ -748,6 +811,59 @@ where
     }
 }
 
+impl<T: Instance> ErrorType for UarteRx<T> {
+    type Error = Error;
+}
+
+impl<T: Instance> ReadReady for UarteRx<T> {
+    fn read_ready(&mut self) -> Result<bool, Self::Error> {
+        let uarte = unsafe { &*T::ptr() };
+
+        compiler_fence(SeqCst);
+
+        if uarte.events_rxstarted.read().bits() == 0 {
+            start_read(uarte, self.rx_buf)?;
+            Ok(false)
+        } else {
+            Ok(uarte.events_endrx.read().bits() != 0)
+        }
+    }
+}
+
+impl<T: Instance> embedded_io::Read for UarteRx<T> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let uarte = unsafe { &*T::ptr() };
+
+        compiler_fence(SeqCst);
+
+        // This complexity to handle in-progress reads is needed because calls to this read method
+        // might be interleaved with calls to serial::Read::read.
+
+        // If no read transaction is started yet, start one and wait for it to start.
+        if uarte.events_rxstarted.read().bits() == 0 {
+            start_read(&uarte, self.rx_buf)?;
+        }
+
+        // Wait for the transaction to finish.
+        while uarte.events_endrx.read().bits() == 0 {
+            spin_loop();
+        }
+
+        // Tidy up and return the byte read.
+        uarte.events_rxstarted.reset();
+        finalize_read(uarte);
+        if uarte.rxd.amount.read().bits() != 1 {
+            return Err(Error::Receive);
+        }
+        buf[0] = self.rx_buf[0];
+        Ok(1)
+    }
+}
+
 impl<T> serial::Read<u8> for UarteRx<T>
 where
     T: Instance,
@@ -768,7 +884,7 @@ where
 
             finalize_read(uarte);
 
-            if uarte.rxd.amount.read().bits() != 1 as u32 {
+            if uarte.rxd.amount.read().bits() != 1 {
                 return Err(nb::Error::Other(Error::Receive));
             }
             Ok(self.rx_buf[0])

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -8,9 +8,9 @@ use core::fmt;
 use core::ops::Deref;
 use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
-use embedded_hal::blocking::serial as bserial;
-use embedded_hal::digital::v2::OutputPin;
-use embedded_hal::serial;
+use embedded_hal_02::blocking::serial as bserial;
+use embedded_hal_02::digital::v2::OutputPin;
+use embedded_hal_02::serial;
 
 #[cfg(any(feature = "52833", feature = "52840"))]
 use crate::pac::UARTE1;


### PR DESCRIPTION
Now that `embedded-hal` 1.0 is released, this PR adds implementations of most of its relevant traits. For now I've added them alongside the existing `embedded-hal` 0.2 trait implementations, so that users can still use drivers based on the old traits. We can remove the old traits in a later release.

I haven't implemented the `embedded-hal-nb` and `embedded-hal-async` traits yet, and the I2C traits are also missing as the design has changed and implementing it correctly is non-trivial.