### PR TITLE
Make embedded-hal 0.2 optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     continue-on-error: ${{ matrix.rust_version == 'nightly' }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Rust stable
       uses: actions-rs/toolchain@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,20 @@ jobs:
           - rust_version: stable
             rustflags: --deny warnings
 
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Copy Cargo.toml
+        run: cp Cargo.ci.toml Cargo.toml
+      - name: Format Rust code
+        run: cargo fmt --all -- --check
+
   ci:
     if: ${{ success() }}
     # all new jobs must be added to this list
-    needs: [build]
+    needs: [build, format]
     runs-on: ubuntu-latest
     steps:
       - name: CI succeeded

--- a/examples/nvmc-demo/src/main.rs
+++ b/examples/nvmc-demo/src/main.rs
@@ -6,7 +6,7 @@
 #[cfg(feature = "52840")]
 use nrf52840_hal as hal;
 
-use core::convert::TryInto;
+use core::{convert::TryInto, ptr::addr_of_mut};
 use embedded_storage::nor_flash::NorFlash;
 use embedded_storage::nor_flash::ReadNorFlash;
 use hal::nvmc::Nvmc;
@@ -33,7 +33,7 @@ fn main() -> ! {
     let p = hal::pac::Peripherals::take().unwrap();
 
     #[cfg(feature = "52840")]
-    let mut nvmc = Nvmc::new(p.NVMC, unsafe { &mut CONFIG });
+    let mut nvmc = Nvmc::new(p.NVMC, unsafe { addr_of_mut!(CONFIG).as_mut().unwrap() });
 
     erase_if_needed(&mut nvmc, LAST_PAGE);
 

--- a/examples/ppi-demo/Cargo.toml
+++ b/examples/ppi-demo/Cargo.toml
@@ -8,7 +8,6 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
-embedded-hal = "0.2.7"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 nrf52810-hal = { path = "../../nrf52810-hal", features = ["rt"], optional = true }

--- a/examples/ppi-demo/Cargo.toml
+++ b/examples/ppi-demo/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = "0.7.0"
+embedded-hal = "0.2.7"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 
 nrf52810-hal = { path = "../../nrf52810-hal", features = ["rt"], optional = true }

--- a/examples/ppi-demo/src/main.rs
+++ b/examples/ppi-demo/src/main.rs
@@ -41,7 +41,6 @@ use {
     },
     cortex_m::interrupt::Mutex,
     cortex_m_rt::entry,
-    embedded_hal::timer::CountDown,
     hal::{
         pac::{interrupt, Interrupt, RADIO},
         ppi,

--- a/examples/ppi-demo/src/main.rs
+++ b/examples/ppi-demo/src/main.rs
@@ -41,6 +41,7 @@ use {
     },
     cortex_m::interrupt::Mutex,
     cortex_m_rt::entry,
+    embedded_hal::timer::CountDown,
     hal::{
         pac::{interrupt, Interrupt, RADIO},
         ppi,

--- a/examples/wdt-demo/Cargo.toml
+++ b/examples/wdt-demo/Cargo.toml
@@ -5,14 +5,9 @@ authors = ["James Munns <james.munns@ferrous-systems.com>"]
 edition = "2018"
 publish = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 cortex-m = "0.7.3"
 cortex-m-rt = { version = "0.7.0", features = ["device"] }
+embedded-hal = "1.0.0"
 rtt-target = { version = "0.3.1", features = ["cortex-m"] }
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
-
-[dependencies.embedded-hal]
-version = "0.2.3"
-features = ["unproven"]

--- a/examples/wdt-demo/src/main.rs
+++ b/examples/wdt-demo/src/main.rs
@@ -14,10 +14,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::{
-    digital::v2::{InputPin, OutputPin},
-    timer::CountDown,
-};
+use embedded_hal::digital::{InputPin, OutputPin};
 use {
     core::panic::PanicInfo,
     hal::{
@@ -37,10 +34,10 @@ fn main() -> ! {
     rtt_init_print!();
     let p0 = hal::gpio::p0::Parts::new(p.P0);
 
-    let btn1 = p0.p0_11.into_pullup_input().degrade();
-    let btn2 = p0.p0_12.into_pullup_input().degrade();
-    let btn3 = p0.p0_24.into_pullup_input().degrade();
-    let btn4 = p0.p0_25.into_pullup_input().degrade();
+    let mut btn1 = p0.p0_11.into_pullup_input().degrade();
+    let mut btn2 = p0.p0_12.into_pullup_input().degrade();
+    let mut btn3 = p0.p0_24.into_pullup_input().degrade();
+    let mut btn4 = p0.p0_25.into_pullup_input().degrade();
 
     let mut led1 = p0.p0_13.into_push_pull_output(Level::High).degrade();
     let mut led2 = p0.p0_14.into_push_pull_output(Level::High).degrade();
@@ -102,7 +99,7 @@ fn main() -> ! {
         rprintln!("Not restarted by the dog!");
     }
 
-    let buttons = [&btn1, &btn2, &btn3, &btn4];
+    let buttons = [&mut btn1, &mut btn2, &mut btn3, &mut btn4];
 
     let leds = [&mut led1, &mut led2, &mut led3, &mut led4];
 

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -20,13 +20,13 @@ license = "MIT OR Apache-2.0"
 edition = "2018"
 
 [dependencies]
-cortex-m = "0.7.3"
-nb = "1.0.0"
-fixed = "1.0.0"
-rand_core = "0.6.3"
+cortex-m = "0.7.7"
+nb = "1.1.0"
+fixed = "1.25.1"
+rand_core = "0.6.4"
 cfg-if = "1.0.0"
 embedded-dma = "0.2.0"
-embedded-storage = "0.3.0"
+embedded-storage = "0.3.1"
 
 [dependencies.void]
 default-features = false
@@ -79,7 +79,7 @@ optional = true
 [dependencies.embedded-hal-02]
 package = "embedded-hal"
 features = ["unproven"]
-version = "0.2.4"
+version = "0.2.7"
 
 [dependencies.embedded-hal]
 version = "1.0.0"

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -80,6 +80,7 @@ optional = true
 package = "embedded-hal"
 features = ["unproven"]
 version = "0.2.7"
+optional = true
 
 [dependencies.embedded-hal]
 version = "1.0.0"

--- a/nrf-hal-common/src/delay.rs
+++ b/nrf-hal-common/src/delay.rs
@@ -5,7 +5,6 @@ use core::convert::TryInto;
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 use embedded_hal::delay::DelayNs;
-use embedded_hal_02::blocking::delay::{DelayMs, DelayUs};
 
 /// System timer (SysTick) as a delay provider.
 pub struct Delay {
@@ -26,37 +25,43 @@ impl Delay {
     }
 }
 
-impl DelayMs<u32> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayMs<u32> for Delay {
     fn delay_ms(&mut self, ms: u32) {
         DelayNs::delay_ms(self, ms);
     }
 }
 
-impl DelayMs<u16> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
         DelayNs::delay_ms(self, ms.into());
     }
 }
 
-impl DelayMs<u8> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayMs<u8> for Delay {
     fn delay_ms(&mut self, ms: u8) {
         DelayNs::delay_ms(self, ms.into());
     }
 }
 
-impl DelayUs<u32> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
         DelayNs::delay_us(self, us);
     }
 }
 
-impl DelayUs<u16> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayUs<u16> for Delay {
     fn delay_us(&mut self, us: u16) {
         DelayNs::delay_us(self, us.into());
     }
 }
 
-impl DelayUs<u8> for Delay {
+#[cfg(feature = "embedded-hal-02")]
+impl embedded_hal_02::blocking::delay::DelayUs<u8> for Delay {
     fn delay_us(&mut self, us: u8) {
         DelayNs::delay_us(self, us.into());
     }

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -86,7 +86,6 @@ use crate::pac::P1;
 use crate::pac::P1_NS as P1;
 
 use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
-use void::Void;
 
 impl<MODE> Pin<MODE> {
     fn new(port: Port, pin: u8) -> Self {
@@ -232,9 +231,11 @@ impl<MODE> Pin<MODE> {
     }
 
     /// Convert the pin to be a push-pull output with specified drive.
-    pub fn into_push_pull_output_drive(self, initial_output: Level, drive: DriveConfig) ->
-        Pin<Output<PushPull>>
-    {
+    pub fn into_push_pull_output_drive(
+        self,
+        initial_output: Level,
+        drive: DriveConfig,
+    ) -> Pin<Output<PushPull>> {
         let mut pin = Pin {
             _mode: PhantomData,
             pin_port: self.pin_port,
@@ -404,8 +405,9 @@ impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<MODE> embedded_hal_02::digital::v2::InputPin for Pin<Input<MODE>> {
-    type Error = Void;
+    type Error = void::Void;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
         self.is_low().map(|v| !v)
@@ -416,8 +418,9 @@ impl<MODE> embedded_hal_02::digital::v2::InputPin for Pin<Input<MODE>> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl embedded_hal_02::digital::v2::InputPin for Pin<Output<OpenDrainIO>> {
-    type Error = Void;
+    type Error = void::Void;
 
     fn is_high(&self) -> Result<bool, Self::Error> {
         self.is_low().map(|v| !v)
@@ -428,8 +431,9 @@ impl embedded_hal_02::digital::v2::InputPin for Pin<Output<OpenDrainIO>> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<MODE> embedded_hal_02::digital::v2::OutputPin for Pin<Output<MODE>> {
-    type Error = Void;
+    type Error = void::Void;
 
     /// Set the output as high.
     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -452,6 +456,7 @@ impl<MODE> embedded_hal_02::digital::v2::OutputPin for Pin<Output<MODE>> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<MODE> embedded_hal_02::digital::v2::StatefulOutputPin for Pin<Output<MODE>> {
     /// Is the output pin set as high?
     fn is_set_high(&self) -> Result<bool, Self::Error> {
@@ -540,7 +545,6 @@ macro_rules! gpio {
 
             use core::convert::Infallible;
             use embedded_hal::digital::{ErrorType, InputPin, OutputPin, StatefulOutputPin};
-            use void::Void;
 
             // ===============================================================
             // This chunk allows you to obtain an nrf-hal gpio from the
@@ -802,8 +806,9 @@ macro_rules! gpio {
                     }
                 }
 
+                #[cfg(feature = "embedded-hal-02")]
                 impl<MODE> embedded_hal_02::digital::v2::InputPin for $PXi<Input<MODE>> {
-                    type Error = Void;
+                    type Error = void::Void;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {
                         self.is_low().map(|v| !v)
@@ -814,8 +819,9 @@ macro_rules! gpio {
                     }
                 }
 
+                #[cfg(feature = "embedded-hal-02")]
                 impl embedded_hal_02::digital::v2::InputPin for $PXi<Output<OpenDrainIO>> {
-                    type Error = Void;
+                    type Error = void::Void;
 
                     fn is_high(&self) -> Result<bool, Self::Error> {
                         self.is_low().map(|v| !v)
@@ -832,8 +838,9 @@ macro_rules! gpio {
                     }
                 }
 
+                #[cfg(feature = "embedded-hal-02")]
                 impl<MODE> embedded_hal_02::digital::v2::OutputPin for $PXi<Output<MODE>> {
-                    type Error = Void;
+                    type Error = void::Void;
 
                     /// Set the output as high
                     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -852,6 +859,7 @@ macro_rules! gpio {
                     }
                 }
 
+                #[cfg(feature = "embedded-hal-02")]
                 impl<MODE> embedded_hal_02::digital::v2::StatefulOutputPin for $PXi<Output<MODE>> {
                     /// Is the output pin set as high?
                     fn is_set_high(&self) -> Result<bool, Self::Error> {

--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -682,10 +682,7 @@ struct Inner<B> {
 impl<B> Transfer<B> {
     /// Returns `true` if the transfer is done.
     pub fn is_done(&self) -> bool {
-        if let Some(inner) = self
-            .inner
-            .as_ref()
-        {
+        if let Some(inner) = self.inner.as_ref() {
             inner.i2s.is_event_triggered(I2SEvent::RxPtrUpdated)
                 || inner.i2s.is_event_triggered(I2SEvent::TxPtrUpdated)
         } else {

--- a/nrf-hal-common/src/ieee802154.rs
+++ b/nrf-hal-common/src/ieee802154.rs
@@ -6,8 +6,6 @@ use core::{
     sync::atomic::{self, Ordering},
 };
 
-use embedded_hal_02::timer::CountDown as _;
-
 use crate::{
     clocks::{Clocks, ExternalOscillator},
     pac::{
@@ -366,7 +364,7 @@ impl<'c> Radio<'c> {
                 break;
             }
 
-            if timer.wait().is_ok() {
+            if timer.reset_if_finished() {
                 // timeout
                 break;
             }

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -112,9 +112,6 @@ pub mod usbd;
 pub mod wdt;
 
 pub mod prelude {
-    pub use embedded_hal_02::digital::v2::*;
-    pub use embedded_hal_02::prelude::*;
-
     #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "5340-net")))]
     pub use crate::ppi::{ConfigurablePpi, Ppi};
     pub use crate::time::U32Ext;

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -869,6 +869,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T: Instance> embedded_hal_02::Pwm for Pwm<T> {
     type Channel = Channel;
     type Duty = u16;
@@ -946,6 +947,7 @@ impl<'a, T: Instance> PwmChannel<'a, T> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmChannel<'a, T> {
     type Duty = u16;
 
@@ -1024,6 +1026,7 @@ impl<'a, T: Instance> PwmGroup<'a, T> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<'a, T: Instance> embedded_hal_02::PwmPin for PwmGroup<'a, T> {
     type Duty = u16;
 

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -14,9 +14,9 @@ use crate::{
     time::*,
 };
 use core::{
-    cell::Cell,
     convert::Infallible,
     ops::Deref,
+    ptr::addr_of_mut,
     sync::atomic::{compiler_fence, Ordering},
 };
 use embedded_dma::*;
@@ -299,7 +299,7 @@ where
     // Internal helper function that returns 15 bit duty cycle value.
     #[inline(always)]
     fn duty_on_value(&self, index: usize) -> u16 {
-        let val = T::buffer().get()[index];
+        let val = unsafe { (*T::buffer())[index] };
         let is_inverted = (val >> 15) & 1 == 0;
         match is_inverted {
             false => val,
@@ -310,7 +310,7 @@ where
     // Internal helper function that returns 15 bit inverted duty cycle value.
     #[inline(always)]
     fn duty_off_value(&self, index: usize) -> u16 {
-        let val = T::buffer().get()[index];
+        let val = unsafe { (*T::buffer())[index] };
         let is_inverted = (val >> 15) & 1 == 0;
         match is_inverted {
             false => self.max_duty() - val,
@@ -321,15 +321,16 @@ where
     /// Sets duty cycle (15 bit) for all PWM channels.
     /// Will replace any ongoing sequence playback.
     pub fn set_duty_on_common(&self, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer.copy_from_slice(&[duty.min(self.max_duty()) & 0x7FFF; 4][..]);
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            *buffer = [duty.min(self.max_duty()) & 0x7FFF; 4];
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Common);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(1) });
         self.start_seq(Seq::Seq0);
     }
@@ -337,15 +338,16 @@ where
     /// Sets inverted duty cycle (15 bit) for all PWM channels.
     /// Will replace any ongoing sequence playback.
     pub fn set_duty_off_common(&self, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer.copy_from_slice(&[duty.min(self.max_duty()) | 0x8000; 4][..]);
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            *buffer = [duty.min(self.max_duty()) | 0x8000; 4];
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Common);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(1) });
         self.start_seq(Seq::Seq0);
     }
@@ -365,15 +367,16 @@ where
     /// Sets duty cycle (15 bit) for a PWM group.
     /// Will replace any ongoing sequence playback.
     pub fn set_duty_on_group(&self, group: Group, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer[usize::from(group)] = duty.min(self.max_duty()) & 0x7FFF;
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            (*buffer)[usize::from(group)] = duty.min(self.max_duty()) & 0x7FFF;
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Grouped);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(2) });
         self.start_seq(Seq::Seq0);
     }
@@ -381,15 +384,16 @@ where
     /// Sets inverted duty cycle (15 bit) for a PWM group.
     /// Will replace any ongoing sequence playback.
     pub fn set_duty_off_group(&self, group: Group, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer[usize::from(group)] = duty.min(self.max_duty()) | 0x8000;
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            (*buffer)[usize::from(group)] = duty.min(self.max_duty()) | 0x8000;
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Grouped);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(2) });
         self.start_seq(Seq::Seq0);
     }
@@ -409,15 +413,16 @@ where
     /// Sets duty cycle (15 bit) for a PWM channel.
     /// Will replace any ongoing sequence playback and the other channels will return to their previously set value.
     pub fn set_duty_on(&self, channel: Channel, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer[usize::from(channel)] = duty.min(self.max_duty()) & 0x7FFF;
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            (*buffer)[usize::from(channel)] = duty.min(self.max_duty()) & 0x7FFF;
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Individual);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(4) });
         self.start_seq(Seq::Seq0);
     }
@@ -425,15 +430,16 @@ where
     /// Sets inverted duty cycle (15 bit) for a PWM channel.
     /// Will replace any ongoing sequence playback and the other channels will return to their previously set value.
     pub fn set_duty_off(&self, channel: Channel, duty: u16) {
-        let mut buffer = T::buffer().get();
-        buffer[usize::from(channel)] = duty.min(self.max_duty()) | 0x8000;
-        T::buffer().set(buffer);
+        let buffer = T::buffer();
+        unsafe {
+            (*buffer)[usize::from(channel)] = duty.min(self.max_duty()) | 0x8000;
+        }
         self.one_shot();
         self.set_load_mode(LoadMode::Individual);
         self.pwm
             .seq0
             .ptr
-            .write(|w| unsafe { w.bits(T::buffer().as_ptr() as u32) });
+            .write(|w| unsafe { w.bits(buffer as u32) });
         self.pwm.seq0.cnt.write(|w| unsafe { w.bits(4) });
         self.start_seq(Seq::Seq0);
     }
@@ -1185,24 +1191,24 @@ pub trait Instance: sealed::Sealed + Deref<Target = RegisterBlock> {
     const INTERRUPT: Interrupt;
 
     /// Provides access to the associated internal duty buffer for the instance.
-    fn buffer() -> &'static Cell<[u16; 4]>;
+    fn buffer() -> *mut [u16; 4];
 }
 
 // Internal static duty buffers. One per instance.
-static mut BUF0: Cell<[u16; 4]> = Cell::new([0; 4]);
+static mut BUF0: [u16; 4] = [0; 4];
 #[cfg(not(any(feature = "52810", feature = "52811")))]
-static mut BUF1: Cell<[u16; 4]> = Cell::new([0; 4]);
+static mut BUF1: [u16; 4] = [0; 4];
 #[cfg(not(any(feature = "52810", feature = "52811")))]
-static mut BUF2: Cell<[u16; 4]> = Cell::new([0; 4]);
+static mut BUF2: [u16; 4] = [0; 4];
 #[cfg(not(any(feature = "52810", feature = "52811", feature = "52832")))]
-static mut BUF3: Cell<[u16; 4]> = Cell::new([0; 4]);
+static mut BUF3: [u16; 4] = [0; 4];
 
 #[cfg(not(any(feature = "9160", feature = "5340-app")))]
 impl Instance for crate::pac::PWM0 {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF0 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF0) }
     }
 }
 
@@ -1214,8 +1220,8 @@ impl Instance for crate::pac::PWM0 {
 )))]
 impl Instance for crate::pac::PWM1 {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF1 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF1) }
     }
 }
 
@@ -1227,8 +1233,8 @@ impl Instance for crate::pac::PWM1 {
 )))]
 impl Instance for crate::pac::PWM2 {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF2 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF2) }
     }
 }
 
@@ -1241,8 +1247,8 @@ impl Instance for crate::pac::PWM2 {
 )))]
 impl Instance for crate::pac::PWM3 {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF3 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF3) }
     }
 }
 
@@ -1250,32 +1256,32 @@ impl Instance for crate::pac::PWM3 {
 impl Instance for crate::pac::PWM0_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF0 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF0) }
     }
 }
 
 #[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM1_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF1 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF1) }
     }
 }
 
 #[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM2_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF2 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF2) }
     }
 }
 
 #[cfg(any(feature = "9160", feature = "5340-app"))]
 impl Instance for crate::pac::PWM3_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
-    fn buffer() -> &'static Cell<[u16; 4]> {
-        unsafe { &BUF3 }
+    fn buffer() -> *mut [u16; 4] {
+        unsafe { addr_of_mut!(BUF3) }
     }
 }
 mod sealed {

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -6,7 +6,6 @@
 #![cfg_attr(not(feature = "52840"), doc = "```ignore")]
 //! # use nrf_hal_common as hal;
 //! # use hal::pac::{saadc, SAADC};
-//! # use embedded_hal_02::adc::OneShot;
 //! // substitute `hal` with the HAL of your board, e.g. `nrf52840_hal`
 //! use hal::{
 //!    pac::Peripherals,
@@ -24,7 +23,7 @@
 //! let mut saadc_pin = gpios.p0_02; // the pin your analog device is connected to
 //!
 //! // blocking read from saadc for `saadc_config.time` microseconds
-//! let _saadc_result = saadc.read(&mut saadc_pin);
+//! let _saadc_result = saadc.read_channel(&mut saadc_pin);
 //! ```
 
 #[cfg(any(feature = "9160", feature = "5340-app"))]
@@ -37,13 +36,20 @@ use core::{
     hint::unreachable_unchecked,
     sync::atomic::{compiler_fence, Ordering::SeqCst},
 };
-use embedded_hal_02::adc::{Channel, OneShot};
 
 pub use saadc::{
     ch::config::{GAIN_A as Gain, REFSEL_A as Reference, RESP_A as Resistor, TACQ_A as Time},
     oversample::OVERSAMPLE_A as Oversample,
     resolution::VAL_A as Resolution,
 };
+
+#[cfg(feature = "embedded-hal-02")]
+pub trait Channel: embedded_hal_02::adc::Channel<Saadc, ID = u8> {}
+
+#[cfg(not(feature = "embedded-hal-02"))]
+pub trait Channel {
+    fn channel() -> u8;
+}
 
 // Only 1 channel is allowed right now, a discussion needs to be had as to how
 // multiple channels should work (See "scan mode" in the datasheet).
@@ -99,6 +105,58 @@ impl Saadc {
     pub fn free(self) -> SAADC {
         self.0.enable.write(|w| w.enable().disabled());
         self.0
+    }
+
+    /// Sample channel `PIN` for the configured ADC acquisition time in differential input mode.
+    /// Note that this is a blocking operation.
+    pub fn read_channel<PIN: Channel>(&mut self, _pin: &mut PIN) -> Result<i16, ()> {
+        match PIN::channel() {
+            0 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input0()),
+            1 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input1()),
+            2 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input2()),
+            3 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input3()),
+            4 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input4()),
+            5 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input5()),
+            6 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input6()),
+            7 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input7()),
+            #[cfg(not(feature = "9160"))]
+            8 => self.0.ch[0].pselp.write(|w| w.pselp().vdd()),
+            #[cfg(any(feature = "52833", feature = "52840"))]
+            13 => self.0.ch[0].pselp.write(|w| w.pselp().vddhdiv5()),
+            // This can never happen the only analog pins have already been defined
+            // PAY CLOSE ATTENTION TO ANY CHANGES TO THIS IMPL OR THE `channel_mappings!` MACRO
+            _ => unsafe { unreachable_unchecked() },
+        }
+
+        let mut val: i16 = 0;
+        self.0
+            .result
+            .ptr
+            .write(|w| unsafe { w.ptr().bits(((&mut val) as *mut _) as u32) });
+        self.0
+            .result
+            .maxcnt
+            .write(|w| unsafe { w.maxcnt().bits(1) });
+
+        // Conservative compiler fence to prevent starting the ADC before the
+        // pointer and maxcount have been set.
+        compiler_fence(SeqCst);
+
+        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
+        self.0.tasks_sample.write(|w| unsafe { w.bits(1) });
+
+        while self.0.events_end.read().bits() == 0 {}
+        self.0.events_end.reset();
+
+        // Will only occur if more than one channel has been enabled.
+        if self.0.result.amount.read().bits() != 1 {
+            return Err(());
+        }
+
+        // Second fence to prevent optimizations creating issues with the EasyDMA-modified `val`.
+        compiler_fence(SeqCst);
+
+        Ok(val)
     }
 }
 
@@ -166,72 +224,35 @@ impl Default for SaadcConfig {
     }
 }
 
-impl<PIN> OneShot<Saadc, i16, PIN> for Saadc
+#[cfg(feature = "embedded-hal-02")]
+impl<PIN> embedded_hal_02::adc::OneShot<Saadc, i16, PIN> for Saadc
 where
-    PIN: Channel<Saadc, ID = u8>,
+    PIN: Channel,
 {
     type Error = ();
 
     /// Sample channel `PIN` for the configured ADC acquisition time in differential input mode.
     /// Note that this is a blocking operation.
-    fn read(&mut self, _pin: &mut PIN) -> nb::Result<i16, Self::Error> {
-        match PIN::channel() {
-            0 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input0()),
-            1 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input1()),
-            2 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input2()),
-            3 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input3()),
-            4 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input4()),
-            5 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input5()),
-            6 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input6()),
-            7 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input7()),
-            #[cfg(not(feature = "9160"))]
-            8 => self.0.ch[0].pselp.write(|w| w.pselp().vdd()),
-            #[cfg(any(feature = "52833", feature = "52840"))]
-            13 => self.0.ch[0].pselp.write(|w| w.pselp().vddhdiv5()),
-            // This can never happen the only analog pins have already been defined
-            // PAY CLOSE ATTENTION TO ANY CHANGES TO THIS IMPL OR THE `channel_mappings!` MACRO
-            _ => unsafe { unreachable_unchecked() },
-        }
-
-        let mut val: i16 = 0;
-        self.0
-            .result
-            .ptr
-            .write(|w| unsafe { w.ptr().bits(((&mut val) as *mut _) as u32) });
-        self.0
-            .result
-            .maxcnt
-            .write(|w| unsafe { w.maxcnt().bits(1) });
-
-        // Conservative compiler fence to prevent starting the ADC before the
-        // pointer and maxcount have been set.
-        compiler_fence(SeqCst);
-
-        self.0.tasks_start.write(|w| unsafe { w.bits(1) });
-        self.0.tasks_sample.write(|w| unsafe { w.bits(1) });
-
-        while self.0.events_end.read().bits() == 0 {}
-        self.0.events_end.reset();
-
-        // Will only occur if more than one channel has been enabled.
-        if self.0.result.amount.read().bits() != 1 {
-            return Err(nb::Error::Other(()));
-        }
-
-        // Second fence to prevent optimizations creating issues with the EasyDMA-modified `val`.
-        compiler_fence(SeqCst);
-
-        Ok(val)
+    fn read(&mut self, pin: &mut PIN) -> nb::Result<i16, Self::Error> {
+        Ok(self.read_channel(pin)?)
     }
 }
 
 macro_rules! channel_mappings {
     ( $($n:expr => $pin:ident,)*) => {
         $(
-            impl<STATE> Channel<Saadc> for crate::gpio::p0::$pin<STATE> {
+            #[cfg(feature = "embedded-hal-02")]
+            impl<STATE> embedded_hal_02::adc::Channel<Saadc> for crate::gpio::p0::$pin<STATE> {
                 type ID = u8;
 
-                fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
+                fn channel() -> u8 {
+                    $n
+                }
+            }
+
+            impl<STATE> Channel for crate::gpio::p0::$pin<STATE> {
+                #[cfg(not(feature = "embedded-hal-02"))]
+                fn channel() -> u8 {
                     $n
                 }
             }
@@ -263,11 +284,19 @@ channel_mappings! {
     7 => P0_31,
 }
 
-#[cfg(not(feature = "9160"))]
-impl Channel<Saadc> for InternalVdd {
+#[cfg(all(not(feature = "9160"), feature = "embedded-hal-02"))]
+impl embedded_hal_02::adc::Channel<Saadc> for InternalVdd {
     type ID = u8;
 
-    fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
+    fn channel() -> u8 {
+        8
+    }
+}
+
+#[cfg(not(feature = "9160"))]
+impl Channel for InternalVdd {
+    #[cfg(not(feature = "embedded-hal-02"))]
+    fn channel() -> u8 {
         8
     }
 }
@@ -276,11 +305,19 @@ impl Channel<Saadc> for InternalVdd {
 /// Channel that doesn't sample a pin, but the internal VDD voltage.
 pub struct InternalVdd;
 
-#[cfg(any(feature = "52833", feature = "52840"))]
-impl Channel<Saadc> for InternalVddHdiv5 {
+#[cfg(all(any(feature = "52833", feature = "52840"), feature = "embedded-hal-02"))]
+impl embedded_hal_02::adc::Channel<Saadc> for InternalVddHdiv5 {
     type ID = u8;
 
-    fn channel() -> <Self as embedded_hal_02::adc::Channel<Saadc>>::ID {
+    fn channel() -> u8 {
+        13
+    }
+}
+
+#[cfg(any(feature = "52833", feature = "52840"))]
+impl Channel for InternalVddHdiv5 {
+    #[cfg(not(feature = "embedded-hal-02"))]
+    fn channel() -> u8 {
         13
     }
 }

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -6,6 +6,7 @@
 #![cfg_attr(not(feature = "52840"), doc = "```ignore")]
 //! # use nrf_hal_common as hal;
 //! # use hal::pac::{saadc, SAADC};
+//! # use embedded_hal_02::adc::OneShot;
 //! // substitute `hal` with the HAL of your board, e.g. `nrf52840_hal`
 //! use hal::{
 //!    pac::Peripherals,

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -32,10 +32,7 @@ use crate::pac::{saadc_ns as saadc, SAADC_NS as SAADC};
 #[cfg(not(any(feature = "9160", feature = "5340-app")))]
 use crate::pac::{saadc, SAADC};
 
-use core::{
-    hint::unreachable_unchecked,
-    sync::atomic::{compiler_fence, Ordering::SeqCst},
-};
+use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 
 pub use saadc::{
     ch::config::{GAIN_A as Gain, REFSEL_A as Reference, RESP_A as Resistor, TACQ_A as Time},
@@ -123,9 +120,9 @@ impl Saadc {
             8 => self.0.ch[0].pselp.write(|w| w.pselp().vdd()),
             #[cfg(any(feature = "52833", feature = "52840"))]
             13 => self.0.ch[0].pselp.write(|w| w.pselp().vddhdiv5()),
-            // This can never happen the only analog pins have already been defined
-            // PAY CLOSE ATTENTION TO ANY CHANGES TO THIS IMPL OR THE `channel_mappings!` MACRO
-            _ => unsafe { unreachable_unchecked() },
+            // This can never happen with the `Channel` implementations provided, as the only analog
+            // pins have already been covered.
+            _ => return Err(()),
         }
 
         let mut val: i16 = 0;

--- a/nrf-hal-common/src/spi.rs
+++ b/nrf-hal-common/src/spi.rs
@@ -7,11 +7,7 @@ use crate::{
 };
 
 use core::{cmp::max, convert::Infallible, hint::spin_loop};
-use embedded_hal::spi::{ErrorType, SpiBus};
-pub use embedded_hal_02::{
-    blocking::spi::{transfer, write, write_iter},
-    spi::{FullDuplex, Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3},
-};
+use embedded_hal::spi::{ErrorType, Mode, SpiBus, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use spi0::frequency::FREQUENCY_A as Frequency;
 
 /// Value written out if the caller requests a read without data to write.
@@ -20,26 +16,32 @@ const DEFAULT_WRITE: u8 = 0x00;
 /// Interface to a SPI instance.
 pub struct Spi<T>(T);
 
-impl<T> write::Default<u8> for Spi<T>
+#[cfg(feature = "embedded-hal-02")]
+impl<T> embedded_hal_02::blocking::spi::write::Default<u8> for Spi<T>
 where
-    Spi<T>: FullDuplex<u8>,
-    T: Instance,
-{
-}
-impl<T> write_iter::Default<u8> for Spi<T>
-where
-    Spi<T>: FullDuplex<u8>,
-    T: Instance,
-{
-}
-impl<T> transfer::Default<u8> for Spi<T>
-where
-    Spi<T>: FullDuplex<u8>,
+    Spi<T>: embedded_hal_02::spi::FullDuplex<u8>,
     T: Instance,
 {
 }
 
-impl<T> FullDuplex<u8> for Spi<T>
+#[cfg(feature = "embedded-hal-02")]
+impl<T> embedded_hal_02::blocking::spi::write_iter::Default<u8> for Spi<T>
+where
+    Spi<T>: embedded_hal_02::spi::FullDuplex<u8>,
+    T: Instance,
+{
+}
+
+#[cfg(feature = "embedded-hal-02")]
+impl<T> embedded_hal_02::blocking::spi::transfer::Default<u8> for Spi<T>
+where
+    Spi<T>: embedded_hal_02::spi::FullDuplex<u8>,
+    T: Instance,
+{
+}
+
+#[cfg(feature = "embedded-hal-02")]
+impl<T> embedded_hal_02::spi::FullDuplex<u8> for Spi<T>
 where
     T: Instance,
 {

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -16,7 +16,7 @@ use crate::pac::{SPIM1_NS as SPIM1, SPIM2_NS as SPIM2, SPIM3_NS as SPIM3};
 #[cfg(not(any(feature = "9160", feature = "5340-app", feature = "5340-net")))]
 use crate::pac::{spim0, SPIM0};
 
-pub use embedded_hal_02::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
+pub use embedded_hal::spi::{Mode, Phase, Polarity, MODE_0, MODE_1, MODE_2, MODE_3};
 pub use spim0::frequency::FREQUENCY_A as Frequency;
 
 use core::iter::repeat_with;
@@ -97,6 +97,7 @@ impl<T: Instance> SpiBus for Spim<T> {
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::spi::Transfer<u8> for Spim<T>
 where
     T: Instance,
@@ -115,6 +116,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::spi::Write<u8> for Spim<T>
 where
     T: Instance,
@@ -146,10 +148,12 @@ impl<T> Spim<T>
 where
     T: Instance,
 {
+    #[cfg(feature = "embedded-hal-02")]
     fn spi_dma_no_copy(&mut self, chunk: &[u8]) -> Result<(), Error> {
         self.do_spi_dma_transfer(DmaSlice::from_slice(chunk), DmaSlice::null())
     }
 
+    #[cfg(feature = "embedded-hal-02")]
     fn spi_dma_copy(&mut self, chunk: &[u8]) -> Result<(), Error> {
         let mut buf = [0u8; FORCE_COPY_BUFFER_SIZE];
         buf[..chunk.len()].copy_from_slice(chunk);

--- a/nrf-hal-common/src/timer.rs
+++ b/nrf-hal-common/src/timer.rs
@@ -23,11 +23,8 @@ use cast::u32;
 use embedded_hal::delay::DelayNs;
 use embedded_hal_02::{
     blocking::delay::{DelayMs, DelayUs},
-    prelude::*,
     timer,
 };
-use nb::{self, block};
-use void::{unreachable, Void};
 
 #[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
 use crate::pac::{TIMER3, TIMER4};
@@ -45,7 +42,7 @@ use crate::pac::timer0::{
     RegisterBlock as RegBlock3, EVENTS_COMPARE as EventsCompare3, TASKS_CAPTURE as TasksCapture3,
 };
 
-use core::marker::PhantomData;
+use core::{hint::spin_loop, marker::PhantomData};
 
 pub struct OneShot;
 pub struct Periodic;
@@ -146,11 +143,34 @@ where
         self.0.disable_interrupt();
     }
 
+    /// Starts the timer.
+    ///
+    /// The timer will run for the given number of cycles, then it will stop and
+    /// reset.
+    pub fn start(&mut self, cycles: u32) {
+        self.0.timer_start(cycles)
+    }
+
+    /// If the timer has finished, resets it and returns true.
+    ///
+    /// Returns false if the timer is still running.
+    pub fn reset_if_finished(&mut self) -> bool {
+        if self.0.timer_running() {
+            // EVENTS_COMPARE has not been triggered yet
+            return false;
+        }
+
+        self.0.timer_reset_event();
+
+        true
+    }
+
+    /// Starts the timer for the given number of cycles and waits for it to
+    /// finish.
     pub fn delay(&mut self, cycles: u32) {
         self.start(cycles);
-        match block!(self.wait()) {
-            Ok(_) => {}
-            Err(x) => unreachable(x),
+        while !self.reset_if_finished() {
+            spin_loop();
         }
     }
 
@@ -268,16 +288,12 @@ where
     ///
     /// To block until the timer has stopped, use the `block!` macro from the
     /// `nb` crate. Please refer to the documentation of `nb` for other options.
-    fn wait(&mut self) -> nb::Result<(), Void> {
-        if self.0.timer_running() {
-            // EVENTS_COMPARE has not been triggered yet
-            return Err(nb::Error::WouldBlock);
+    fn wait(&mut self) -> nb::Result<(), void::Void> {
+        if self.reset_if_finished() {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
         }
-
-        // Reset the event, otherwise it will always read `1` from now on.
-        self.0.timer_reset_event();
-
-        Ok(())
     }
 }
 

--- a/nrf-hal-common/src/timer.rs
+++ b/nrf-hal-common/src/timer.rs
@@ -19,12 +19,9 @@ use crate::pac::{
     },
     Interrupt, TIMER0, TIMER1, TIMER2,
 };
+#[cfg(feature = "embedded-hal-02")]
 use cast::u32;
 use embedded_hal::delay::DelayNs;
-use embedded_hal_02::{
-    blocking::delay::{DelayMs, DelayUs},
-    timer,
-};
 
 #[cfg(any(feature = "52832", feature = "52833", feature = "52840"))]
 use crate::pac::{TIMER3, TIMER4};
@@ -263,7 +260,8 @@ where
     }
 }
 
-impl<T, U> timer::CountDown for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::timer::CountDown for Timer<T, U>
 where
     T: Instance,
 {
@@ -297,7 +295,8 @@ where
     }
 }
 
-impl<T, U> timer::Cancel for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::timer::Cancel for Timer<T, U>
 where
     T: Instance,
 {
@@ -309,36 +308,41 @@ where
     }
 }
 
-impl<T> timer::Periodic for Timer<T, Periodic> where T: Instance {}
+#[cfg(feature = "embedded-hal-02")]
+impl<T> embedded_hal_02::timer::Periodic for Timer<T, Periodic> where T: Instance {}
 
-impl<T, U> DelayMs<u32> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayMs<u32> for Timer<T, U>
 where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u32) {
-        DelayUs::delay_us(self, ms * 1_000);
+        embedded_hal_02::blocking::delay::DelayUs::delay_us(self, ms * 1_000);
     }
 }
 
-impl<T, U> DelayMs<u16> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayMs<u16> for Timer<T, U>
 where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u16) {
-        DelayMs::delay_ms(self, u32(ms));
+        embedded_hal_02::blocking::delay::DelayMs::delay_ms(self, u32(ms));
     }
 }
 
-impl<T, U> DelayMs<u8> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayMs<u8> for Timer<T, U>
 where
     T: Instance,
 {
     fn delay_ms(&mut self, ms: u8) {
-        DelayMs::delay_ms(self, u32(ms));
+        embedded_hal_02::blocking::delay::DelayMs::delay_ms(self, u32(ms));
     }
 }
 
-impl<T, U> DelayUs<u32> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayUs<u32> for Timer<T, U>
 where
     T: Instance,
 {
@@ -347,21 +351,23 @@ where
     }
 }
 
-impl<T, U> DelayUs<u16> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayUs<u16> for Timer<T, U>
 where
     T: Instance,
 {
     fn delay_us(&mut self, us: u16) {
-        DelayUs::delay_us(self, u32(us))
+        embedded_hal_02::blocking::delay::DelayUs::delay_us(self, u32(us))
     }
 }
 
-impl<T, U> DelayUs<u8> for Timer<T, U>
+#[cfg(feature = "embedded-hal-02")]
+impl<T, U> embedded_hal_02::blocking::delay::DelayUs<u8> for Timer<T, U>
 where
     T: Instance,
 {
     fn delay_us(&mut self, us: u8) {
-        DelayUs::delay_us(self, u32(us))
+        embedded_hal_02::blocking::delay::DelayUs::delay_us(self, u32(us))
     }
 }
 

--- a/nrf-hal-common/src/twi.rs
+++ b/nrf-hal-common/src/twi.rs
@@ -250,6 +250,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Write for Twi<T>
 where
     T: Instance,
@@ -261,6 +262,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Read for Twi<T>
 where
     T: Instance,
@@ -272,6 +274,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::WriteRead for Twi<T>
 where
     T: Instance,

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -21,7 +21,7 @@ use crate::pac::TWIM1;
 
 use crate::{
     gpio::{Floating, Input, Pin},
-    slice_in_ram, slice_in_ram_or,
+    slice_in_ram_or,
     target_constants::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE},
 };
 
@@ -394,6 +394,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Write for Twim<T>
 where
     T: Instance,
@@ -401,7 +402,7 @@ where
     type Error = Error;
 
     fn write<'w>(&mut self, addr: u8, bytes: &'w [u8]) -> Result<(), Error> {
-        if slice_in_ram(bytes) {
+        if crate::slice_in_ram(bytes) {
             self.write(addr, bytes)
         } else {
             let buf = &mut [0; FORCE_COPY_BUFFER_SIZE][..];
@@ -414,6 +415,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::Read for Twim<T>
 where
     T: Instance,
@@ -425,6 +427,7 @@ where
     }
 }
 
+#[cfg(feature = "embedded-hal-02")]
 impl<T> embedded_hal_02::blocking::i2c::WriteRead for Twim<T>
 where
     T: Instance,
@@ -437,7 +440,7 @@ where
         bytes: &'w [u8],
         buffer: &'w mut [u8],
     ) -> Result<(), Error> {
-        if slice_in_ram(bytes) {
+        if crate::slice_in_ram(bytes) {
             self.write_then_read(addr, bytes, buffer)
         } else {
             self.copy_write_then_read(addr, bytes, buffer)

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -13,6 +13,8 @@ use core::sync::atomic::{compiler_fence, Ordering::SeqCst};
 use embedded_hal_02::blocking::serial as bserial;
 use embedded_hal_02::digital::v2::OutputPin;
 use embedded_hal_02::serial;
+use embedded_hal_02::serial::Write as _;
+use embedded_hal_02::timer::CountDown as _;
 use embedded_io::{ErrorKind, ErrorType, ReadReady, WriteReady};
 
 #[cfg(any(feature = "52833", feature = "52840"))]
@@ -34,7 +36,6 @@ use crate::pac::UARTE1_NS as UARTE1;
 use crate::pac::{uarte0, UARTE0};
 
 use crate::gpio::{Floating, Input, Output, Pin, PushPull};
-use crate::prelude::*;
 use crate::slice_in_ram_or;
 use crate::target_constants::EASY_DMA_SIZE;
 use crate::timer::{self, Timer};

--- a/nrf-hal-common/src/uarte.rs
+++ b/nrf-hal-common/src/uarte.rs
@@ -14,7 +14,6 @@ use embedded_hal_02::blocking::serial as bserial;
 use embedded_hal_02::digital::v2::OutputPin;
 use embedded_hal_02::serial;
 use embedded_hal_02::serial::Write as _;
-use embedded_hal_02::timer::CountDown as _;
 use embedded_io::{ErrorKind, ErrorType, ReadReady, WriteReady};
 
 #[cfg(any(feature = "52833", feature = "52840"))]
@@ -264,7 +263,7 @@ where
 
         loop {
             event_complete |= self.0.events_endrx.read().bits() != 0;
-            timeout_occured |= timer.wait().is_ok();
+            timeout_occured |= timer.reset_if_finished();
             if event_complete || timeout_occured {
                 break;
             }

--- a/nrf51-hal/Cargo.toml
+++ b/nrf51-hal/Cargo.toml
@@ -29,9 +29,10 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf51-pac/rt"]
 # Note: We use the xxAB package by default because it has the least amount of available resources.
-default = ["rt", "xxAB-package"]
+default = ["rt", "xxAB-package", "embedded-hal-02"]
 xxAA-package = []
 xxAB-package = []
 xxAC-package = []

--- a/nrf51-hal/Cargo.toml
+++ b/nrf51-hal/Cargo.toml
@@ -27,10 +27,6 @@ default-features = false
 features = ["51"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf51-pac/rt"]

--- a/nrf51-hal/src/lib.rs
+++ b/nrf51-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf51-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 }
 

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -26,10 +26,6 @@ default-features = false
 features = ["52810"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf52810-pac/rt"]

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -28,5 +28,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf52810-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf52810-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::ccm::Ccm;

--- a/nrf52811-hal/Cargo.toml
+++ b/nrf52811-hal/Cargo.toml
@@ -27,5 +27,6 @@ features = ["52811"]
 version = "=0.16.1"
 
 [features]
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf52811-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf52811-hal/Cargo.toml
+++ b/nrf52811-hal/Cargo.toml
@@ -26,10 +26,6 @@ default-features = false
 features = ["52811"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 rt = ["nrf52811-pac/rt"]
 default = ["rt"]

--- a/nrf52811-hal/src/lib.rs
+++ b/nrf52811-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::ccm::Ccm;

--- a/nrf52811-hal/src/lib.rs
+++ b/nrf52811-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf52811-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -24,10 +24,6 @@ default-features = false
 features = ["52832"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf52832-pac/rt"]

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -26,10 +26,11 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf52832-pac/rt"]
 xxAA-package = []
 xxAB-package = []
 
 # Note: We use the xxAB package because it has the least amount of available resources.
 #   However, most users will want to use the xxAA package.
-default = ["rt", "xxAB-package"]
+default = ["rt", "xxAB-package", "embedded-hal-02"]

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf52832-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 }
 

--- a/nrf52833-hal/Cargo.toml
+++ b/nrf52833-hal/Cargo.toml
@@ -29,5 +29,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf52833-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf52833-hal/Cargo.toml
+++ b/nrf52833-hal/Cargo.toml
@@ -27,10 +27,6 @@ default-features = false
 features = ["52833"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf52833-pac/rt"]

--- a/nrf52833-hal/src/lib.rs
+++ b/nrf52833-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf52833-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/nrf52833-hal/src/lib.rs
+++ b/nrf52833-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::ccm::Ccm;

--- a/nrf52840-hal-tests/tests/nvmc.rs
+++ b/nrf52840-hal-tests/tests/nvmc.rs
@@ -5,6 +5,7 @@ use defmt_rtt as _;
 use nrf52840_hal as _;
 use panic_probe as _;
 
+use core::ptr::addr_of_mut;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 use nrf52840_hal::{nvmc::Nvmc, pac};
 
@@ -32,7 +33,7 @@ mod tests {
         let p = unwrap!(pac::Peripherals::take());
 
         State {
-            nvmc: Nvmc::new(p.NVMC, unsafe { &mut CONFIG }),
+            nvmc: Nvmc::new(p.NVMC, unsafe { addr_of_mut!(CONFIG).as_mut().unwrap() }),
         }
     }
 

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -28,5 +28,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf52840-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -26,10 +26,6 @@ default-features = false
 features = ["52840"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf52840-pac/rt"]

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf52840-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::ccm::Ccm;

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -26,5 +26,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf5340-app-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -24,10 +24,6 @@ default-features = false
 features = ["5340-app"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf5340-app-pac/rt"]

--- a/nrf5340-app-hal/src/lib.rs
+++ b/nrf5340-app-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::clocks::Clocks;

--- a/nrf5340-app-hal/src/lib.rs
+++ b/nrf5340-app-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf5340-app-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/nrf5340-net-hal/Cargo.toml
+++ b/nrf5340-net-hal/Cargo.toml
@@ -20,10 +20,6 @@ default-features = false
 features = ["5340-net"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf5340-net-pac/rt"]

--- a/nrf5340-net-hal/Cargo.toml
+++ b/nrf5340-net-hal/Cargo.toml
@@ -22,5 +22,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf5340-net-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf5340-net-hal/src/lib.rs
+++ b/nrf5340-net-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf5340-net-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use crate::time::U32Ext;
     pub use nrf_hal_common::prelude::*;
 }

--- a/nrf5340-net-hal/src/lib.rs
+++ b/nrf5340-net-hal/src/lib.rs
@@ -4,7 +4,6 @@
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::time::U32Ext;
     pub use nrf_hal_common::prelude::*;
 }
 pub use crate::clocks::Clocks;

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -25,5 +25,6 @@ version = "=0.16.1"
 
 [features]
 doc = []
+embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]
 rt = ["nrf9160-pac/rt"]
-default = ["rt"]
+default = ["rt", "embedded-hal-02"]

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -23,10 +23,6 @@ default-features = false
 features = ["9160"]
 version = "=0.16.1"
 
-[dependencies.embedded-hal]
-features = ["unproven"]
-version = "0.2.3"
-
 [features]
 doc = []
 rt = ["nrf9160-pac/rt"]

--- a/nrf9160-hal/src/lib.rs
+++ b/nrf9160-hal/src/lib.rs
@@ -5,8 +5,6 @@ pub use nrf_hal_common::*;
 
 pub mod prelude {
     pub use nrf_hal_common::prelude::*;
-
-    pub use crate::time::U32Ext;
 }
 
 pub use crate::clocks::Clocks;

--- a/nrf9160-hal/src/lib.rs
+++ b/nrf9160-hal/src/lib.rs
@@ -1,11 +1,9 @@
 #![no_std]
 #![doc(html_root_url = "https://docs.rs/nrf9160-hal/0.16.1")]
 
-use embedded_hal as hal;
 pub use nrf_hal_common::*;
 
 pub mod prelude {
-    pub use crate::hal::prelude::*;
     pub use nrf_hal_common::prelude::*;
 
     pub use crate::time::U32Ext;

--- a/xtask/tests/ci.rs
+++ b/xtask/tests/ci.rs
@@ -33,10 +33,30 @@ fn main() {
 
     // Build-test every HAL.
     for (hal, target) in HALS {
-        let mut cargo = Command::new("cargo");
         let toml_path = format!("{}/Cargo.toml", hal);
+        // With default features.
+        let mut cargo = Command::new("cargo");
         let status = cargo
             .args(&["build", "--manifest-path", &toml_path, "--target", target])
+            .status()
+            .map_err(|e| format!("could not execute {:?}: {}", cargo, e))
+            .unwrap();
+        assert!(
+            status.success(),
+            "command exited with error status: {:?}",
+            cargo
+        );
+        // Without default features.
+        let mut cargo = Command::new("cargo");
+        let status = cargo
+            .args(&[
+                "build",
+                "--manifest-path",
+                &toml_path,
+                "--target",
+                target,
+                "--no-default-features",
+            ])
             .status()
             .map_err(|e| format!("could not execute {:?}: {}", cargo, e))
             .unwrap();
@@ -104,11 +124,17 @@ fn main() {
         }
     }
 
-
     let mut cargo = Command::new("cargo");
     let toml_path = "nrf52840-hal-tests/Cargo.toml";
     let status = cargo
-        .args(&["build", "--manifest-path", &toml_path, "--target", "thumbv7em-none-eabihf", "--tests"])
+        .args(&[
+            "build",
+            "--manifest-path",
+            &toml_path,
+            "--target",
+            "thumbv7em-none-eabihf",
+            "--tests",
+        ])
         .status()
         .map_err(|e| format!("could not execute {:?}: {}", cargo, e))
         .unwrap();


### PR DESCRIPTION
This required some refactoring as some of the embedded-hal 1.0 implementations depended on the embedded-hal 0.2 implementations.