### PR TITLE
fixed 52820 config warning

### DIFF
--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -136,8 +136,10 @@ pub mod target_constants {
     pub const EASY_DMA_SIZE: usize = (1 << 10) - 1;
     #[cfg(feature = "52811")]
     pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
-    #[cfg(feature = "52820")]
-    pub const EASY_DMA_SIZE: usize = (1 << 15) - 1;
+    //  Currently there is no nrf52820-hal. Would be great
+    //  to fix this.
+    //  #[cfg(feature = "52820")]
+    //  pub const EASY_DMA_SIZE: usize = (1 << 15) - 1;
     #[cfg(feature = "52832")]
     pub const EASY_DMA_SIZE: usize = (1 << 8) - 1;
     #[cfg(feature = "52833")]


### PR DESCRIPTION
The latest Rust 1.80 generates a warning for a reference to `cfg(feature = "52820")`, which is not currently a thing — for some reason there is not yet an `nrf52820-hal` crate. This warning gets turned into a failure in CI.

"Fixed" by commenting out the offending code.