### PR TITLE
hid unecessary unsafes in pwm.rs for back compatibility

### DIFF
--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -1209,7 +1209,9 @@ impl Instance for crate::pac::PWM0 {
     #[inline(always)]
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF0) }
+        unsafe {
+            addr_of_mut!(BUF0)
+        }
     }
 }
 
@@ -1223,7 +1225,9 @@ impl Instance for crate::pac::PWM1 {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF1) }
+        unsafe {
+            addr_of_mut!(BUF1)
+        }
     }
 }
 
@@ -1237,7 +1241,9 @@ impl Instance for crate::pac::PWM2 {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF2) }
+        unsafe {
+            addr_of_mut!(BUF2)
+        }
     }
 }
 
@@ -1252,7 +1258,9 @@ impl Instance for crate::pac::PWM3 {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF3) }
+        unsafe {
+            addr_of_mut!(BUF3)
+        }
     }
 }
 
@@ -1262,7 +1270,9 @@ impl Instance for crate::pac::PWM0_NS {
     #[inline(always)]
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF0) }
+        unsafe {
+            addr_of_mut!(BUF0)
+        }
     }
 }
 
@@ -1271,7 +1281,9 @@ impl Instance for crate::pac::PWM1_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF1) }
+        unsafe {
+            addr_of_mut!(BUF1)
+        }
     }
 }
 
@@ -1280,7 +1292,9 @@ impl Instance for crate::pac::PWM2_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF2) }
+        unsafe {
+            addr_of_mut!(BUF2)
+        }
     }
 }
 
@@ -1289,7 +1303,9 @@ impl Instance for crate::pac::PWM3_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
     fn buffer() -> *mut [u16; 4] {
         #[allow(unused_unsafe)]
-        unsafe { addr_of_mut!(BUF3) }
+        unsafe {
+            addr_of_mut!(BUF3)
+        }
     }
 }
 mod sealed {

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -1208,6 +1208,7 @@ impl Instance for crate::pac::PWM0 {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF0) }
     }
 }
@@ -1221,6 +1222,7 @@ impl Instance for crate::pac::PWM0 {
 impl Instance for crate::pac::PWM1 {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF1) }
     }
 }
@@ -1234,6 +1236,7 @@ impl Instance for crate::pac::PWM1 {
 impl Instance for crate::pac::PWM2 {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF2) }
     }
 }
@@ -1248,6 +1251,7 @@ impl Instance for crate::pac::PWM2 {
 impl Instance for crate::pac::PWM3 {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF3) }
     }
 }
@@ -1257,6 +1261,7 @@ impl Instance for crate::pac::PWM0_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM0;
     #[inline(always)]
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF0) }
     }
 }
@@ -1265,6 +1270,7 @@ impl Instance for crate::pac::PWM0_NS {
 impl Instance for crate::pac::PWM1_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM1;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF1) }
     }
 }
@@ -1273,6 +1279,7 @@ impl Instance for crate::pac::PWM1_NS {
 impl Instance for crate::pac::PWM2_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM2;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF2) }
     }
 }
@@ -1281,6 +1288,7 @@ impl Instance for crate::pac::PWM2_NS {
 impl Instance for crate::pac::PWM3_NS {
     const INTERRUPT: Interrupt = Interrupt::PWM3;
     fn buffer() -> *mut [u16; 4] {
+        #[allow(unused_unsafe)]
         unsafe { addr_of_mut!(BUF3) }
     }
 }


### PR DESCRIPTION
Recent Rust warns about unnecessary `unsafe` wrapping `addr_of_mut!()`. Suppress these warnings for now.