### PR TITLE
fixed new rustc 1.89 lifetime elision warnings

### DIFF
--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -59,42 +59,42 @@ impl Gpiote {
         Self { gpiote }
     }
 
-    fn channel(&self, channel: usize) -> GpioteChannel {
+    fn channel(&self, channel: usize) -> GpioteChannel<'_> {
         GpioteChannel {
             gpiote: &self.gpiote,
             channel,
         }
     }
-    pub fn channel0(&self) -> GpioteChannel {
+    pub fn channel0(&self) -> GpioteChannel<'_> {
         self.channel(0)
     }
-    pub fn channel1(&self) -> GpioteChannel {
+    pub fn channel1(&self) -> GpioteChannel<'_> {
         self.channel(1)
     }
-    pub fn channel2(&self) -> GpioteChannel {
+    pub fn channel2(&self) -> GpioteChannel<'_> {
         self.channel(2)
     }
-    pub fn channel3(&self) -> GpioteChannel {
+    pub fn channel3(&self) -> GpioteChannel<'_> {
         self.channel(3)
     }
     #[cfg(not(feature = "51"))]
-    pub fn channel4(&self) -> GpioteChannel {
+    pub fn channel4(&self) -> GpioteChannel<'_> {
         self.channel(4)
     }
     #[cfg(not(feature = "51"))]
-    pub fn channel5(&self) -> GpioteChannel {
+    pub fn channel5(&self) -> GpioteChannel<'_> {
         self.channel(5)
     }
     #[cfg(not(feature = "51"))]
-    pub fn channel6(&self) -> GpioteChannel {
+    pub fn channel6(&self) -> GpioteChannel<'_> {
         self.channel(6)
     }
     #[cfg(not(feature = "51"))]
-    pub fn channel7(&self) -> GpioteChannel {
+    pub fn channel7(&self) -> GpioteChannel<'_> {
         self.channel(7)
     }
 
-    pub fn port(&self) -> GpiotePort {
+    pub fn port(&self) -> GpiotePort<'_> {
         GpiotePort {
             gpiote: &self.gpiote,
         }

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -738,7 +738,14 @@ where
 
     /// Returns individual handles to the four PWM channels.
     #[inline(always)]
-    pub fn split_channels(&self) -> (PwmChannel<T>, PwmChannel<T>, PwmChannel<T>, PwmChannel<T>) {
+    pub fn split_channels(
+        &self,
+    ) -> (
+        PwmChannel<'_, T>,
+        PwmChannel<'_, T>,
+        PwmChannel<'_, T>,
+        PwmChannel<'_, T>,
+    ) {
         (
             PwmChannel::new(self, Channel::C0),
             PwmChannel::new(self, Channel::C1),
@@ -748,7 +755,7 @@ where
     }
 
     /// Returns individual handles to the two PWM groups.
-    pub fn split_groups(&self) -> (PwmGroup<T>, PwmGroup<T>) {
+    pub fn split_groups(&self) -> (PwmGroup<'_, T>, PwmGroup<'_, T>) {
         (
             PwmGroup::new(self, Group::G0),
             PwmGroup::new(self, Group::G1),


### PR DESCRIPTION
With rustc 1.89 new compiler warnings were added for "confusing" lifetime elision cases. This commit quiets the compiler.