### PR TITLE
I2s contoller demo heapless 09

### DIFF
--- a/examples/i2s-controller-demo/Cargo.toml
+++ b/examples/i2s-controller-demo/Cargo.toml
@@ -13,5 +13,5 @@ embedded-hal = "1.0.0"
 systick-monotonic = "1.0.0"
 rtt-target = "0.6.0"
 nrf52840-hal = { features = ["rt"], path = "../../nrf52840-hal" }
-heapless = "0.8.0"
+heapless = "0.9.1"
 small_morse = "0.1.0"

--- a/examples/i2s-controller-demo/Embed.toml
+++ b/examples/i2s-controller-demo/Embed.toml
@@ -15,7 +15,7 @@ protocol = "Swd"
 enabled = true
 # Whether or not the target should be halted after reset.
 # DEPRECATED, moved to reset section
-halt_afterwards = false
+#halt_afterwards = false
 # Whether or not bytes erased but not rewritten with data from the ELF
 # should be restored with their contents before erasing.
 restore_unwritten_bytes = false
@@ -43,13 +43,14 @@ log_level = "WARN"
 # This is exclusive and cannot be used with GDB at the moment.
 enabled = true
 # A list of channel associations to be displayed. If left empty, all channels are displayed.
-channels = [
-    # { up = 0, down = 0, name = "name", format = "String" }
+up_channels = [
+    # { name = "name", format = "String" }
+]
+down_channels = [
+    # { name = "name", format = "String" }
 ]
 # The duration in ms for which the logger should retry to attach to RTT.
 timeout = 3000
-# Whether timestamps in the RTTUI are enabled
-show_timestamps = true
 # Whether to save rtt history buffer on exit.
 log_enabled = false
 # Where to save rtt history buffer relative to manifest path.

--- a/examples/i2s-controller-demo/src/main.rs
+++ b/examples/i2s-controller-demo/src/main.rs
@@ -41,8 +41,8 @@ mod app {
     struct Local {
         signal_buf: &'static [i16; 32],
         mute_buf: &'static [i16; 32],
-        producer: Producer<'static, State, 257>,
-        consumer: Consumer<'static, State, 257>,
+        producer: Producer<'static, State>,
+        consumer: Consumer<'static, State>,
         uarte: Uarte<UARTE0>,
         uarte_timer: Timer<TIMER0>,
         gpiote: Gpiote,


### PR DESCRIPTION
Fixed up `i2s-controller-demo` example `Embed.toml` to match current `cargo-embed`. Updated `heapless` in example to `0.9.1`.

Closes #528