### PR TITLE
fixed clippy and rustfmt warnings in nrf-hal-common

### DIFF
--- a/nrf-hal-common/src/ccm.rs
+++ b/nrf-hal-common/src/ccm.rs
@@ -241,7 +241,7 @@ impl Ccm {
 
         // Shortcut, CCM won't encrypt packet with empty payloads, it will just copy the header
         if payload_len == 0 {
-            (&mut cipher_packet[..HEADER_SIZE]).copy_from_slice(&clear_packet[..HEADER_SIZE]);
+            cipher_packet[..HEADER_SIZE].copy_from_slice(&clear_packet[..HEADER_SIZE]);
             return Ok(());
         }
 
@@ -367,7 +367,7 @@ impl Ccm {
 
         // Shortcut, CCM won't decrypt packet with empty payloads, it will just copy the header
         if payload_len == 0 {
-            (&mut clear_packet[..HEADER_SIZE]).copy_from_slice(&cipher_packet[..HEADER_SIZE]);
+            clear_packet[..HEADER_SIZE].copy_from_slice(&cipher_packet[..HEADER_SIZE]);
             return Ok(());
         }
 

--- a/nrf-hal-common/src/gpio.rs
+++ b/nrf-hal-common/src/gpio.rs
@@ -41,7 +41,7 @@ pub enum Port {
     /// Port 0, available on all nRF52 and nRF51 MCUs.
     Port0,
     /// Port 0 Secure, available on nRF53
-    #[cfg(any(feature = "5340-app"))]
+    #[cfg(feature = "5340-app")]
     Port0Secure,
     /// Port 1, only available on some nRF52 MCUs and nRF5340.
     #[cfg(any(feature = "52833", feature = "52840", feature = "5340-net"))]
@@ -91,7 +91,7 @@ impl<MODE> Pin<MODE> {
     fn new(port: Port, pin: u8) -> Self {
         let port_bits = match port {
             Port::Port0 => 0x00,
-            #[cfg(any(feature = "5340-app"))]
+            #[cfg(feature = "5340-app")]
             Port::Port0Secure => 0x20,
             #[cfg(any(feature = "52833", feature = "52840", feature = "5340-net"))]
             Port::Port1 => 0x20,
@@ -102,6 +102,11 @@ impl<MODE> Pin<MODE> {
         }
     }
 
+    /// Construct a GPIO directly from port selection bits.
+    ///
+    /// # Safety
+    ///
+    /// Must be called with valid `psel_bits`.
     pub unsafe fn from_psel_bits(psel_bits: u32) -> Self {
         Self {
             pin_port: psel_bits as u8,
@@ -143,7 +148,7 @@ impl<MODE> Pin<MODE> {
             }
         }
 
-        #[cfg(any(feature = "5340-app"))]
+        #[cfg(feature = "5340-app")]
         {
             if self.pin_port & 0x20 == 0 {
                 Port::Port0

--- a/nrf-hal-common/src/gpiote.rs
+++ b/nrf-hal-common/src/gpiote.rs
@@ -121,16 +121,16 @@ impl<'a> GpioteChannel<'_> {
     /// Configures the channel as an event input with associated pin.
     pub fn input_pin<P: GpioteInputPin>(&'a self, pin: &'a P) -> GpioteChannelEvent<'a, P> {
         GpioteChannelEvent {
-            gpiote: &self.gpiote,
-            pin: pin,
+            gpiote: self.gpiote,
+            pin,
             channel: self.channel,
         }
     }
     /// Configures the channel as a task output with associated pin.
     pub fn output_pin<P: GpioteOutputPin>(&'a self, pin: P) -> GpioteTask<'a, P> {
         GpioteTask {
-            gpiote: &self.gpiote,
-            pin: pin,
+            gpiote: self.gpiote,
+            pin,
             channel: self.channel,
             task_out_polarity: TaskOutPolarity::Toggle,
         }
@@ -220,7 +220,7 @@ pub struct GpioteChannelEvent<'a, P: GpioteInputPin> {
     channel: usize,
 }
 
-impl<'a, P: GpioteInputPin> GpioteChannelEvent<'_, P> {
+impl<P: GpioteInputPin> GpioteChannelEvent<'_, P> {
     /// Generates event on falling edge.
     pub fn hi_to_lo(&self) -> &Self {
         config_channel_event_pin(self.gpiote, self.channel, self.pin, EventPolarity::HiToLo);
@@ -284,7 +284,7 @@ pub struct GpiotePortEvent<'a, P: GpioteInputPin> {
     pin: &'a P,
 }
 
-impl<'a, P: GpioteInputPin> GpiotePortEvent<'_, P> {
+impl<P: GpioteInputPin> GpiotePortEvent<'_, P> {
     /// Generates event on pin low.
     pub fn low(&self) {
         config_port_event_pin(self.pin, PortEventSense::Low);
@@ -325,7 +325,7 @@ pub struct GpioteTask<'a, P: GpioteOutputPin> {
     task_out_polarity: TaskOutPolarity,
 }
 
-impl<'a, P: GpioteOutputPin> GpioteTask<'_, P> {
+impl<P: GpioteOutputPin> GpioteTask<'_, P> {
     /// Sets initial task output pin state to high.
     pub fn init_high(&self) {
         config_channel_task_pin(

--- a/nrf-hal-common/src/i2s.rs
+++ b/nrf-hal-common/src/i2s.rs
@@ -365,6 +365,11 @@ impl I2S {
     }
 
     /// Sets the receive buffer RAM start address.
+    ///
+    /// # Safety
+    ///
+    /// `addr` must be the address of writeable static memory of
+    /// sufficient size to hold the specified receive buffer.
     #[inline(always)]
     pub unsafe fn set_rx_ptr(&self, addr: u32) -> Result<(), Error> {
         if (addr as usize) < SRAM_LOWER || (addr as usize) > SRAM_UPPER {
@@ -375,6 +380,11 @@ impl I2S {
     }
 
     /// Sets the size (in 32bit words) of the receive and transmit buffers.
+    ///
+    /// # Safety
+    ///
+    /// `n_32bit` must be no longer than the DMA buffer pointed to
+    /// by this struct.
     #[inline(always)]
     pub unsafe fn set_buffersize(&self, n_32bit: u32) -> Result<(), Error> {
         if n_32bit > MAX_DMA_MAXCNT {

--- a/nrf-hal-common/src/ieee802154.rs
+++ b/nrf-hal-common/src/ieee802154.rs
@@ -458,6 +458,7 @@ impl<'c> Radio<'c> {
     /// ensure the `packet` buffer is allocated in RAM, which is required by the RADIO peripheral
     // NOTE we do NOT check the address of `packet` because the mutable reference ensures it's
     // allocated in RAM
+    #[allow(clippy::result_unit_err)]
     pub fn try_send(&mut self, packet: &mut Packet) -> Result<(), ()> {
         // enable radio to perform cca
         self.put_in_rx_mode();
@@ -779,6 +780,12 @@ pub struct Packet {
 }
 
 // See figure 124 in nRF52840-PS
+impl Default for Packet {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Packet {
     // for indexing purposes
     const PHY_HDR: usize = 0;
@@ -812,6 +819,7 @@ impl Packet {
     }
 
     /// Returns the size of this packet's payload
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> u8 {
         self.buffer[Self::PHY_HDR] - Self::CRC
     }

--- a/nrf-hal-common/src/nvmc.rs
+++ b/nrf-hal-common/src/nvmc.rs
@@ -16,8 +16,7 @@ use embedded_storage::nor_flash::{
     ErrorType, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
 };
 
-type WORD = u32;
-const WORD_SIZE: usize = core::mem::size_of::<WORD>();
+const WORD_SIZE: usize = core::mem::size_of::<u32>();
 const PAGE_SIZE: usize = 4 * 1024;
 
 /// Interface to an NVMC instance.
@@ -162,7 +161,7 @@ where
 
     fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
         let offset = offset as usize;
-        if bytes.len() > self.capacity() || offset as usize > self.capacity() - bytes.len() {
+        if bytes.len() > self.capacity() || offset > self.capacity() - bytes.len() {
             return Err(NvmcError::OutOfBounds);
         }
         if offset % WORD_SIZE != 0 || bytes.len() % WORD_SIZE != 0 {

--- a/nrf-hal-common/src/pwm.rs
+++ b/nrf-hal-common/src/pwm.rs
@@ -541,6 +541,7 @@ where
     /// Loads the given sequence buffers and optionally (re-)starts sequence playback.
     /// Returns a `PemSeq`, containing `Pwm<T>` and the buffers.
     #[allow(unused_mut)]
+    #[allow(clippy::type_complexity)]
     pub fn load<B0, B1>(
         mut self,
         seq0_buffer: Option<B0>,

--- a/nrf-hal-common/src/saadc.rs
+++ b/nrf-hal-common/src/saadc.rs
@@ -106,6 +106,7 @@ impl Saadc {
 
     /// Sample channel `PIN` for the configured ADC acquisition time in differential input mode.
     /// Note that this is a blocking operation.
+    #[allow(clippy::result_unit_err)]
     pub fn read_channel<PIN: Channel>(&mut self, _pin: &mut PIN) -> Result<i16, ()> {
         match PIN::channel() {
             0 => self.0.ch[0].pselp.write(|w| w.pselp().analog_input0()),

--- a/nrf-hal-common/src/spim.rs
+++ b/nrf-hal-common/src/spim.rs
@@ -388,7 +388,7 @@ where
             // the iterators.
             let txi = tx_buffer
                 .chunks(EASY_DMA_SIZE)
-                .map(|chunk| DmaSlice::from_slice(chunk))
+                .map(DmaSlice::from_slice)
                 .chain(repeat_with(DmaSlice::null));
             let rxi = rx_buffer
                 .chunks_mut(EASY_DMA_SIZE)

--- a/nrf-hal-common/src/spis.rs
+++ b/nrf-hal-common/src/spis.rs
@@ -356,6 +356,7 @@ where
     /// The buffers must be located in RAM.
     /// Returns a value that represents the in-progress DMA transfer.
     #[allow(unused_mut)]
+    #[allow(clippy::type_complexity)]
     pub fn transfer_split<TxW, RxW, TxB, RxB>(
         mut self,
         tx_buffer: TxB,

--- a/nrf-hal-common/src/time.rs
+++ b/nrf-hal-common/src/time.rs
@@ -49,20 +49,20 @@ impl U32Ext for u32 {
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(val: KiloHertz) -> Self {
+        Hertz(val.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(val: MegaHertz) -> Self {
+        Hertz(val.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(val: MegaHertz) -> Self {
+        KiloHertz(val.0 * 1_000)
     }
 }

--- a/nrf-hal-common/src/twim.rs
+++ b/nrf-hal-common/src/twim.rs
@@ -105,7 +105,7 @@ where
     unsafe fn set_tx_buffer(&mut self, buffer: &[u8]) -> Result<(), Error> {
         slice_in_ram_or(buffer, Error::DMABufferNotInDataMemory)?;
 
-        if buffer.len() == 0 {
+        if buffer.is_empty() {
             return Err(Error::TxBufferZeroLength);
         }
         if buffer.len() > EASY_DMA_SIZE {
@@ -137,7 +137,7 @@ where
         // NOTE: RAM slice check is not necessary, as a mutable
         // slice can only be built from data located in RAM.
 
-        if buffer.len() == 0 {
+        if buffer.is_empty() {
             return Err(Error::RxBufferZeroLength);
         }
         if buffer.len() > EASY_DMA_SIZE {
@@ -553,11 +553,8 @@ impl<T: Instance> I2c for Twim<T> {
 
                         // Send the buffer in chunks immediately.
                         let num_chunks = buffer.len().div_ceil(FORCE_COPY_BUFFER_SIZE);
-                        for (chunk_index, chunk) in buffer
-                            .chunks(FORCE_COPY_BUFFER_SIZE)
-                            .into_iter()
-                            .enumerate()
-                        {
+                        let chunks = buffer.chunks(FORCE_COPY_BUFFER_SIZE).enumerate();
+                        for (chunk_index, chunk) in chunks {
                             tx_copy[..chunk.len()].copy_from_slice(chunk);
                             self.write_part(
                                 &tx_copy[..chunk.len()],
@@ -568,7 +565,7 @@ impl<T: Instance> I2c for Twim<T> {
                         // Copy the current buffer to `tx_copy`. It must fit, as otherwise we
                         // would have hit one of the cases above.
                         tx_copy[pending_tx_bytes..pending_tx_bytes + buffer.len()]
-                            .copy_from_slice(&buffer);
+                            .copy_from_slice(buffer);
                         pending_tx_bytes += buffer.len();
 
                         // If the next operation is not a write (or there is no next operation),


### PR DESCRIPTION
Fixed a bunch of long-standing clippy and rustfmt issues in nrf-hal-common in a minimally-intrusive fashion.