### PR TITLE
Make quadrature decoder input pins generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 (no changes)
 
+## [0.20.0]
+
+### Breaking changes
+
+- Made pin modes for `qdec` generic
+
 ## [0.19.0]
 
 ### Breaking changes
@@ -445,3 +451,4 @@ None
 [0.17.1]: https://github.com/nrf-rs/nrf-hal/releases/tag/v0.17.1
 [0.18.0]: https://github.com/nrf-rs/nrf-hal/releases/tag/v0.18.0
 [0.19.0]: https://github.com/nrf-rs/nrf-hal/releases/tag/v0.19.0
+[0.20.0]: https://github.com/nrf-rs/nrf-hal/releases/tag/v0.20.0

--- a/examples/qdec-demo/src/main.rs
+++ b/examples/qdec-demo/src/main.rs
@@ -6,7 +6,7 @@ use {core::panic::PanicInfo, nrf52840_hal as hal, rtt_target::rprintln};
 #[rtic::app(device = crate::hal::pac, peripherals = true)]
 mod app {
     use {
-        hal::qdec::*,
+        hal::{gpio::PullUp, qdec::*},
         nrf52840_hal as hal,
         rtt_target::{rprintln, rtt_init_print},
     };
@@ -16,7 +16,7 @@ mod app {
 
     #[local]
     struct Local {
-        qdec: Qdec,
+        qdec: Qdec<PullUp>,
         value: i16,
     }
 

--- a/nrf-hal-common/Cargo.toml
+++ b/nrf-hal-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf-hal-common"
-version = "0.19.0"
+version = "0.20.0"
 description = "Implementation details of the nRF HAL crates. Don't use this directly, use one of the specific HAL crates instead (`nrfXYZ-hal`)."
 readme = "../README.md"
 

--- a/nrf-hal-common/src/lib.rs
+++ b/nrf-hal-common/src/lib.rs
@@ -1,7 +1,7 @@
 //! Implementation details of the nRF HAL crates. Don't use this directly, use one of the specific
 //! HAL crates instead (`nrfXYZ-hal`).
 
-#![doc(html_root_url = "https://docs.rs/nrf-hal-common/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf-hal-common/0.20.0")]
 #![no_std]
 
 #[cfg(feature = "rtic-monotonic")]

--- a/nrf-hal-common/src/qdec.rs
+++ b/nrf-hal-common/src/qdec.rs
@@ -4,18 +4,25 @@
 //! It is suitable for mechanical and optical sensors.
 
 use {
-    crate::gpio::{Input, Pin, PullUp},
+    crate::gpio::{Input, Pin},
     crate::pac::QDEC,
+    core::marker::PhantomData,
 };
 
-/// A safe wrapper around the `QDEC` peripheral with associated pins.
-pub struct Qdec {
+/// A safe wrapper around the `QDEC` peripheral with
+/// associated pins.  The `MODE` here reflects the pin mode
+/// of all of the pins when *not* in use by the `QDEC`: that
+/// is, at `new()`-time and `free()`-time.
+pub struct Qdec<MODE> {
     qdec: QDEC,
+    _i: PhantomData<MODE>,
 }
 
-impl Qdec {
-    /// Takes ownership of the `QDEC` peripheral and associated pins, returning a safe wrapper.
-    pub fn new(qdec: QDEC, pins: Pins, sample_period: SamplePeriod) -> Self {
+impl<MODE> Qdec<MODE> {
+    /// Takes ownership of the `QDEC` peripheral and
+    /// associated pins, returning a safe wrapper.
+    /// All pins must be in the given input `MODE`.
+    pub fn new(qdec: QDEC, pins: Pins<MODE>, sample_period: SamplePeriod) -> Self {
         qdec.psel.a.write(|w| {
             unsafe { w.bits(pins.a.psel_bits()) };
             w.connect().connected()
@@ -46,7 +53,10 @@ impl Qdec {
             SamplePeriod::_131ms => qdec.sampleper.write(|w| w.sampleper()._131ms()),
         }
 
-        Self { qdec }
+        Self {
+            qdec,
+            _i: PhantomData,
+        }
     }
 
     /// Enables/disables input debounce filters.
@@ -131,9 +141,12 @@ impl Qdec {
         self.qdec.accread.read().bits() as i16
     }
 
-    /// Consumes `self` and returns back the raw `QDEC` peripheral.
+    /// Consumes `self` and returns back the raw `QDEC`
+    /// peripheral and its pins. The pins are returned in
+    /// the input `MODE` they were in at the time of
+    /// `QDec::new()`.
     #[inline]
-    pub fn free(self) -> (QDEC, Pins) {
+    pub fn free(self) -> (QDEC, Pins<MODE>) {
         let a = unsafe { Pin::from_psel_bits(self.qdec.psel.a.read().bits()) };
         let b = unsafe { Pin::from_psel_bits(self.qdec.psel.b.read().bits()) };
         let led = {
@@ -152,13 +165,29 @@ impl Qdec {
     }
 }
 
-/// Pins for the QDEC
-pub struct Pins {
-    pub a: Pin<Input<PullUp>>,
-    pub b: Pin<Input<PullUp>>,
-    pub led: Option<Pin<Input<PullUp>>>,
+/// Pins for the QDEC. The `led` pin must be given to the
+/// nRF configured as an input, but starting the QDEC will
+/// transform it into an output. The generic input `MODE`
+/// should be either `PullUp`, `PullDown` or `Floating`
+/// depending on circuit requirements.
+///
+/// **Note:** The requirement that all pins be in the same
+/// input `MODE` at startup is not strictly enforced by the
+/// hardware, which cares only whether these pins are
+/// inputs. It is instead a convenience to avoid carrying
+/// around three type parameters, two of which would almost
+/// certainly be redundant (A and B modes) and one of which
+/// is often unnecessary (LED mode).
+pub struct Pins<MODE> {
+    pub a: Pin<Input<MODE>>,
+    pub b: Pin<Input<MODE>>,
+    pub led: Option<Pin<Input<MODE>>>,
 }
 
+/// Period with which to sample the encoder. Note that
+/// periods named in "`ms`" are approximations to exact
+/// periods in µs. When debounce is enabled, the inputs will
+/// be ignored unless they stay stable for this period.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum SamplePeriod {
     _128us,
@@ -174,6 +203,8 @@ pub enum SamplePeriod {
     _131ms,
 }
 
+/// Number of samples before a decoder interrupt is
+/// triggered.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum NumSamples {
     _10smpl,
@@ -187,6 +218,7 @@ pub enum NumSamples {
     _1smpl,
 }
 
+/// Accomodation for high-side LED setups.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum LedPolarity {
     ActiveHigh,

--- a/nrf51-hal/Cargo.toml
+++ b/nrf51-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf51-hal"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2018"
 description = "HAL for nRF51 microcontrollers"
 readme = "../README.md"
@@ -25,7 +25,7 @@ nrf51-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["51"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf51-hal/src/lib.rs
+++ b/nrf51-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf51-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf51-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52805-hal/Cargo.toml
+++ b/nrf52805-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52805-hal"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2018"
 description = "HAL for nRF52805 microcontrollers"
 readme = "../README.md"
@@ -24,7 +24,7 @@ nrf52805-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52805"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf52805-hal/src/lib.rs
+++ b/nrf52805-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52805-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52805-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52810-hal/Cargo.toml
+++ b/nrf52810-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52810-hal"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2018"
 description = "HAL for nRF52810 microcontrollers"
 readme = "../README.md"
@@ -24,7 +24,7 @@ nrf52810-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52810"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf52810-hal/src/lib.rs
+++ b/nrf52810-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52810-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52810-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52811-hal/Cargo.toml
+++ b/nrf52811-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52811-hal"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2018"
 description = "HAL for nRF52811 microcontrollers"
 readme = "../README.md"
@@ -24,7 +24,7 @@ nrf52811-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52811"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 embedded-hal-02 = ["nrf-hal-common/embedded-hal-02"]

--- a/nrf52811-hal/src/lib.rs
+++ b/nrf52811-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52811-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52811-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52832-hal/Cargo.toml
+++ b/nrf52832-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52832-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF52832 microcontrollers"
 readme = "../README.md"
 
@@ -22,7 +22,7 @@ nrf52832-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52832"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf52832-hal/src/lib.rs
+++ b/nrf52832-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52832-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52832-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52833-hal/Cargo.toml
+++ b/nrf52833-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52833-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF52833 microcontrollers"
 readme = "../README.md"
 
@@ -25,7 +25,7 @@ nrf52833-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52833"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf52833-hal/src/lib.rs
+++ b/nrf52833-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52833-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52833-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf52840-hal/Cargo.toml
+++ b/nrf52840-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf52840-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF52840 microcontrollers"
 readme = "../README.md"
 
@@ -24,7 +24,7 @@ nrf52840-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["52840"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf52840-hal/src/lib.rs
+++ b/nrf52840-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf52840-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf52840-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf5340-app-hal/Cargo.toml
+++ b/nrf5340-app-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf5340-app-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF5340 app SoC"
 readme = "README.md"
 
@@ -22,7 +22,7 @@ nrf5340-app-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["5340-app"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf5340-app-hal/src/lib.rs
+++ b/nrf5340-app-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf5340-app-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf5340-app-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf5340-net-hal/Cargo.toml
+++ b/nrf5340-net-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf5340-net-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF5340 net SoC"
 readme = "../README.md"
 
@@ -18,7 +18,7 @@ nrf5340-net-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["5340-net"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf5340-net-hal/src/lib.rs
+++ b/nrf5340-net-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf5340-net-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf5340-net-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 

--- a/nrf9160-hal/Cargo.toml
+++ b/nrf9160-hal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nrf9160-hal"
-version = "0.19.0"
+version = "0.20.0"
 description = "HAL for nRF9160 system-in-package"
 readme = "README.md"
 
@@ -21,7 +21,7 @@ nrf9160-pac = "0.12.2"
 path = "../nrf-hal-common"
 default-features = false
 features = ["9160"]
-version = "=0.19.0"
+version = "=0.20.0"
 
 [features]
 doc = []

--- a/nrf9160-hal/src/lib.rs
+++ b/nrf9160-hal/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![doc(html_root_url = "https://docs.rs/nrf9160-hal/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/nrf9160-hal/0.20.0")]
 
 pub use nrf_hal_common::*;
 


### PR DESCRIPTION
The QDEC quarature decoder input pin struct `qdec::Pins` had the input pins hard-locked to `PUllUp`. Some decoder circuits really want `Floating`. This patch generalizes that.

~~Maybe a breaking change, but I don't think so?~~